### PR TITLE
feat(data-tables, ui, types, preload): Unified editing pages and support backend table loading/updating

### DIFF
--- a/docs/專案提示詞紀錄/專案提示詞紀錄-10.md
+++ b/docs/專案提示詞紀錄/專案提示詞紀錄-10.md
@@ -1911,12 +1911,3 @@ await window.api.uploadTable({ name: "測試表格" }, [{ a: 1, b: 2 }]);
 
 需要我幫你補出 `updateTable` 的後端實作嗎？還是你想先試接前端？
 
-
-## ChatGPT 提問 
-## ChatGPT 回答 
-## ChatGPT 提問 
-## ChatGPT 回答 
-## ChatGPT 提問 
-## ChatGPT 回答 
-## ChatGPT 提問 
-## ChatGPT 回答 

--- a/docs/專案提示詞紀錄/專案提示詞紀錄-10.md
+++ b/docs/專案提示詞紀錄/專案提示詞紀錄-10.md
@@ -1292,10 +1292,626 @@ import { DataTableMetadata } from '../shared/types/dataTable' // 如果沒用 pa
 需要我幫你產出一份範例的 `shared/types/` 型別與 tsconfig 調整模板嗎？還是你想要我幫你寫進 README 的開發說明？
 
 
-## ChatGPT 提問 
-## ChatGPT 回答 
-## ChatGPT 提問 
-## ChatGPT 回答 
+## ChatGPT 提問 串接前後端+dataTable
+🧩 專案背景：
+- 使用技術：
+  - 前端 Vite + React + MUI + Zustand + TypeScript
+  - 後端 Electron + better-sqlite3
+- 專案類型：資料視覺化儀表板
+- 目前架構：
+```front end
+  src/
+  ├── assets/data.json, snake.jpg
+  ├── components/common/ConfirmCancelButtons.tsx, DataTable.tsx, EditableCell.tsx, EditableTitle.tsx, Logo.tsx, PageHeader.tsx, SimpleTable.tsx
+  ├── components/DataTablesPage/DataTableList.tsx, UploadDataTableDialog.tsx
+  ├── components/layout/Breadcrumb.tsx, layout.css, Layout.tsx, PageWrapper.tsx, RightPanel.tsx, Sidebar.tsx, TocList.tsx, TocListItem.tsx, TopNav.tsx
+  ├── context/LayoutContext.tsx, LayoutProvider.tsx, useLayoutContext.tsx
+  ├── hooks/useFileParser.tsx, useTableEditor.tsx
+  ├── pages/ChartEditorPage.tsx, ChartsPage.tsx, ChartViewPage.tsx, DashboardPage.tsx, DashboardsPage.tsx, DataTableEditorPage.tsx, DataTablesPage.tsx, DownloadPage.tsx, HomePage.tsx, TestingPage.tsx, UploadPage.tsx
+  ├── stores/layoutStore.ts
+  ├── theme/index.ts
+  ├── App.tsx
+  ├── main.tsx
+  ├── mui.d.ts
+  ├── types.tsx
+  ├── utils.tsx
+  └── vite-env.d.ts
+```
+```backend
+  electron/
+  ├── ipc/APIModule.cts, ChartAPIHandlers.cts, DashboardAPIHandlers.cts, DataTableAPIHandlers.cts
+  ├── models/ChartManager.cts, DatabaseManager.cts, DataTableManager.cts, FileManager.cts
+  ├── node_modules/.tmp/tsconfig.electron.tsbuildinfo
+  ├── services/DataTableService.cts
+  ├── windows/mainWindow.cts
+  ├── constants.cts
+  ├── main.cts
+  ├── preload.cts
+  ├── tsconfig.json
+  ├── types.cts
+  └── utils.cts
+```
+
+🧱 已完成項目：
+- ipc: 以綁定 DataTable 資料表相關 API 如下
+
+```ts preload.cts
+console.log("Preload script loaded");
+import { contextBridge, ipcRenderer } from "electron";
+contextBridge.exposeInMainWorld("api", {
+  uploadTable: (
+    tableInfo: { name: string; description?: string },
+    content: Record<string, string | number | boolean | null | undefined>[]
+  ) => ipcRenderer.invoke("upload-table", { tableInfo, content }),
+  getAllTableInfos: () => ipcRenderer.invoke("get-all-table-infos"),
+  getTable: (id: number) => ipcRenderer.invoke("get-table", id),
+  deleteTable: (id: number) => ipcRenderer.invoke("delete-table", id),
+  uploadChart: (
+    chartInfo: { name: string; description?: string },
+    config: unknown
+  ) => ipcRenderer.invoke("upload-chart", { chartInfo, config }),
+  deleteChart: (id: number) => ipcRenderer.invoke("delete-chart", id),
+});
+console.log("Preload script end");
+```
+
+🔧 目前狀態：
+```ts
+// src/pages/DataTablesPage.tsx
+import { useState } from "react";
+import {
+  Box,
+  Typography,
+  TextField,
+  Button,
+  Grid,
+  ToggleButtonGroup,
+  ToggleButton,
+} from "@mui/material";
+import FormatListBulletedIcon from "@mui/icons-material/FormatListBulleted";
+import AddIcon from "@mui/icons-material/Add";
+import GridViewIcon from "@mui/icons-material/GridView";
+import { PageWrapper } from "../components/layout/PageWrapper";
+import type { PageConfig } from "../types";
+import { DataTableList } from "../components/DataTablesPage/DataTableList";
+import { UploadDataTableDialog } from "../components/DataTablesPage/UploadDataTableDialog";
+
+// 假資料，用於模擬從後端獲取的資料
+const fakeDataTableInfos = [
+  {
+    id: "1",
+    name: "銷售數據",
+    file_path: "ttt.ss.ddf",
+    created_at: "2023-10-26",
+    updated_at: "2023-10-26",
+    fileSize: "1.2 MB",
+  },
+  {
+    id: "2",
+    name: "客戶資訊",
+    file_path: "ttt.ss.ddf",
+    created_at: "2023-10-25",
+    updated_at: "2023-10-25",
+    fileSize: "800 KB",
+  },
+  {
+    id: "3",
+    name: "庫存報表",
+    file_path: "ttt.ss.ddf",
+    created_at: "2023-10-24",
+    updated_at: "2023-10-24",
+    fileSize: "3.5 MB",
+  },
+];
+
+export const DataTablesPage = () => {
+  const [searchText, setSearchText] = useState("");
+  const [uploadDialogOpen, setUploadDialogOpen] = useState(false);
+  const [viewMode, setViewMode] = useState<"card" | "list">("card");
+
+  // 根據搜尋關鍵字過濾資料
+  const filteredDataTables = fakeDataTableInfos.filter((table) =>
+    table.name.toLowerCase().includes(searchText.toLowerCase())
+  );
+
+  const handleViewModeChange = (
+    _event: React.MouseEvent<HTMLElement>,
+    newViewMode: "card" | "list"
+  ) => {
+    // 只有當新模式不為 null 時才更新狀態
+    if (newViewMode !== null) {
+      setViewMode(newViewMode);
+    }
+  };
+
+  // 頁面配置
+  const pageConfig: Omit<PageConfig, "tocItems"> = {
+    breadcrumbItems: [{ label: "資料表格管理", path: "/data-tables" }],
+    content: (
+      <Box sx={{ p: 3 }}>
+        <Grid container alignItems="center" spacing={2} sx={{ mb: 3 }}>
+          <Grid
+            size={{ xs: 12, sm: 6 }}
+            container
+            alignItems="center"
+            spacing={2}
+          >
+            {/* 標題與模式切換按鈕 */}
+            <Grid>
+              <Typography variant="h4" sx={{ fontWeight: "bold" }}>
+                資料表格管理
+              </Typography>
+            </Grid>
+            <Grid>
+              <ToggleButtonGroup
+                value={viewMode}
+                exclusive
+                onChange={handleViewModeChange}
+                aria-label="view mode"
+                size="small"
+              >
+                <ToggleButton value="card" aria-label="card view">
+                  <GridViewIcon />
+                </ToggleButton>
+                <ToggleButton value="list" aria-label="list view">
+                  <FormatListBulletedIcon />
+                </ToggleButton>
+              </ToggleButtonGroup>
+            </Grid>
+          </Grid>
+          <Grid
+            size={{ xs: 12, sm: 6 }}
+            container
+            justifyContent="flex-end"
+            spacing={1}
+          >
+            {/* 搜尋框 */}
+            <Grid>
+              <TextField
+                label="搜尋表格"
+                variant="outlined"
+                size="small"
+                value={searchText}
+                onChange={(e) => setSearchText(e.target.value)}
+              />
+            </Grid>
+            {/* 上傳按鈕 */}
+            <Grid>
+              <Button
+                variant="contained"
+                startIcon={<AddIcon />}
+                onClick={() => setUploadDialogOpen(true)}
+              >
+                上傳資料表格
+              </Button>
+            </Grid>
+          </Grid>
+        </Grid>
+
+        {/* 將 viewMode 作為 props 傳遞給 DataTableList */}
+        <DataTableList dataTables={filteredDataTables} viewMode={viewMode} />
+
+        {/* 上傳資料表格對話框 */}
+        <UploadDataTableDialog
+          open={uploadDialogOpen}
+          onClose={() => setUploadDialogOpen(false)}
+        />
+      </Box>
+    ),
+  };
+
+  return <PageWrapper {...pageConfig} />;
+};
+```
+
+```ts
+// src/pages/DataTableEditorPage.tsx
+import React, { useEffect } from "react";
+import { useLocation, useNavigate } from "react-router-dom";
+import { Box, Typography, CircularProgress, Alert } from "@mui/material";
+import { PageWrapper } from "../components/layout/PageWrapper";
+import EditableTitle from "../components/common/EditableTitle";
+import ConfirmCancelButtons from "../components/common/ConfirmCancelButtons";
+import DataTable from "../components/common/DataTable";
+import PageHeader from "../components/common/PageHeader";
+import { useFileParser } from "../hooks/useFileParser";
+import { useTableEditor } from "../hooks/useTableEditor";
+
+export const DataTableEditorPage: React.FC = () => {
+  const location = useLocation();
+  const navigate = useNavigate();
+  const file: File | null = location.state?.file || null;
+
+  // 使用自定義 hooks
+  const { loading, data: parsedData, error } = useFileParser(file);
+  const {
+    tableName,
+    setTableName,
+    isEditingName,
+    setIsEditingName,
+    data,
+    handleCellChange,
+    updateData,
+  } = useTableEditor(null, file?.name.split(".")[0] || "未命名表格");
+
+  // 當解析完成時更新資料
+  useEffect(() => {
+    if (parsedData) {
+      updateData(parsedData);
+    }
+  }, [parsedData, updateData]);
+
+  const handleConfirm = () => {
+    console.log(`確認並儲存表格: ${tableName}`);
+    // 這裡可以加入儲存資料到後端的邏輯
+    navigate("/data-tables");
+  };
+
+  const handleCancel = () => {
+    console.log("取消編輯");
+    navigate("/data-tables");
+  };
+
+  const renderContent = () => {
+    if (loading) return <CircularProgress />;
+    if (error) return <Alert severity="error">{error}</Alert>;
+    if (!data) return null;
+
+    return <DataTable data={data} onCellChange={handleCellChange} />;
+  };
+
+  const renderHeaderLeftContent = () => {
+    if (error) {
+      return (
+        <Box sx={{ display: "flex", alignItems: "center" }}>
+          <Typography variant="h4" sx={{ mr: 1, fontWeight: "bold" }}>
+            無檔案資料
+          </Typography>
+        </Box>
+      );
+    }
+
+    return (
+      <EditableTitle
+        title={tableName}
+        onTitleChange={setTableName}
+        isEditing={isEditingName}
+        onEditingChange={setIsEditingName}
+        label="表格名稱"
+        placeholder="請輸入表格名稱"
+      />
+    );
+  };
+
+  const pageConfig = {
+    breadcrumbItems: [
+      { label: "資料表格管理", path: "/data-tables" },
+      { label: "編輯資料表格", path: "" },
+    ],
+    content: (
+      <Box sx={{ p: 3 }}>
+        <PageHeader
+          headerLeftContent={renderHeaderLeftContent()}
+          headerRightContent={
+            <ConfirmCancelButtons
+              onConfirm={handleConfirm}
+              onCancel={handleCancel}
+              showConfirm={!error}
+            />
+          }
+        />
+        {renderContent()}
+      </Box>
+    ),
+    rightPanelContent: (
+      <Box sx={{ p: 2 }}>
+        <Typography variant="h6">編輯控制面板</Typography>
+        <Typography variant="body2" sx={{ mt: 1 }}>
+          這裡可以添加欄位類型、篩選、排序等控制項。
+        </Typography>
+      </Box>
+    ),
+  };
+
+  return <PageWrapper {...pageConfig} />;
+};
+```
+
+❓接下來想處理的問題：
+確實連接上前後端，包含:
+- 資料表格列表呈現
+- 單一資料表格編輯頁面呈現
+- 資料表格上傳
+
+## ChatGPT 回答 串接前後端+dataTable
+你已經完成了非常紮實的基礎架構！目前前後端的 IPC 框架 (`preload.ts` 與 Electron IPC handlers) 都已經就緒，接下來要做的就是把 **前端連接到你已經寫好的後端 IPC 方法**，讓資料可以真正地從 SQLite 資料庫中來去。
+
+---
+
+### ✅ 你的目標
+
+你現在的目標是：
+
+1. **在資料表格頁面（`DataTablesPage.tsx`）載入後端提供的資料表格列表**
+2. **上傳新資料表格時，實際儲存到資料庫**
+3. **編輯頁面能夠根據資料庫中的表格顯示內容與進行更新**
+
+---
+
+### 🧭 下一步具體實作流程
+
+---
+
+#### 🔗 1. 資料表格列表串接後端
+
+##### 📍修改：`DataTablesPage.tsx`
+
+```ts
+import { useEffect, useState } from "react";
+// ...
+const [tableInfos, setTableInfos] = useState<any[]>([]); // 真正從後端來的資料
+
+useEffect(() => {
+  // 載入後端資料表資訊
+  window.api.getAllTableInfos().then((tables) => {
+    setTableInfos(tables);
+  });
+}, []);
+```
+
+##### 🔍 替換 `fakeDataTableInfos` 的地方：
+
+```ts
+// 你原本是用 fakeDataTableInfos，現在改用從後端來的資料：
+const filteredDataTables = tableInfos.filter((table) =>
+  table.name.toLowerCase().includes(searchText.toLowerCase())
+);
+```
+
+---
+
+#### ⬆️ 2. 上傳資料表格串接後端
+
+##### 📍修改：`UploadDataTableDialog.tsx`
+
+這個元件應該有個邏輯像是：
+
+```ts
+const handleUpload = async () => {
+  const parsedContent = // CSV or Excel parsed content
+  const tableInfo = { name: tableName, description: "" };
+  await window.api.uploadTable(tableInfo, parsedContent);
+  onClose(); // 關閉對話框
+};
+```
+
+* ⚠️ 記得成功上傳後，要通知 `DataTablesPage.tsx` **重新 fetch** 列表資料。
+
+  * 做法：`UploadDataTableDialog` 接收一個 `onUploadSuccess: () => void` props，在上傳完成後呼叫它。
+  * 在 `DataTablesPage.tsx` 中重新呼叫 `getAllTableInfos()`。
+
+---
+
+#### 📝 3. 編輯頁面載入後端的資料表內容
+
+##### 📍修改：`DataTableEditorPage.tsx`
+
+目前你是從 `file` 來載入資料，但要改為「若從 URL 傳來的是資料表 `id`，就去後端撈資料」。
+
+建議你修改頁面成這樣支援兩種模式：
+
+```ts
+const location = useLocation();
+const navigate = useNavigate();
+const tableId: number | undefined = location.state?.id;
+const file: File | null = location.state?.file || null;
+
+useEffect(() => {
+  if (tableId) {
+    // 若有 id，從後端載入
+    window.api.getTable(tableId).then((res) => {
+      setTableName(res.name);
+      updateData(res.rows); // 假設 rows 是表格的資料列
+    });
+  } else if (parsedData) {
+    // 否則從上傳的檔案解析
+    updateData(parsedData);
+  }
+}, [parsedData, tableId]);
+```
+
+你也可以用 URL path param（`useParams`）而非 `location.state`，這樣更直覺。
+
+---
+
+#### 💾 4. 儲存功能
+
+目前 `handleConfirm` 尚未實作真正儲存邏輯。你應該要：
+
+```ts
+const handleConfirm = async () => {
+  if (tableId) {
+    // 更新現有資料
+    await window.api.updateTable(tableId, tableName, data);
+  } else {
+    // 上傳新資料表
+    await window.api.uploadTable({ name: tableName }, data);
+  }
+  navigate("/data-tables");
+};
+```
+
+##### ➕ 補充：你目前在 `preload.ts` 中尚未提供 `updateTable` API，需要加上
+
+```ts
+updateTable: (id: number, name: string, data: Record<string, any>[]) =>
+  ipcRenderer.invoke("update-table", { id, name, data }),
+```
+
+再搭配 `electron/ipc/DataTableAPIHandlers.cts` 中新增 `ipcMain.handle("update-table", ...)` 對應。
+
+---
+
+### 🔄 總結整合
+
+| 功能         | 前端位置                    | 使用的 IPC                        |
+| ------------ | --------------------------- | --------------------------------- |
+| 資料表列表   | `DataTablesPage.tsx`        | `getAllTableInfos()`              |
+| 上傳表格     | `UploadDataTableDialog.tsx` | `uploadTable()`                   |
+| 編輯表格頁面 | `DataTableEditorPage.tsx`   | `getTable(id)`、`updateTable(id)` |
+
+---
+
+### ✅ Todo 清單
+
+* [x] `preload.ts`：完成大部分 IPC 方法註冊
+* [ ] 加上 `updateTable()` 的 IPC 接口
+* [x] `DataTablesPage.tsx` 改為讀取 `getAllTableInfos()` 的資料
+* [x] `UploadDataTableDialog.tsx` 呼叫 `uploadTable()`，並能刷新列表
+* [x] `DataTableEditorPage.tsx` 根據 `id` 載入資料表內容
+* [x] `DataTableEditorPage.tsx` 的儲存功能整合 `upload` 或 `update`
+
+---
+
+如果你願意提供 `UploadDataTableDialog.tsx`、`useFileParser.tsx`、`useTableEditor.tsx` 等檔案，我可以幫你具體修改上傳串接的邏輯。不然照著上面步驟其實你應該就可以順利接上了！
+
+要不要我幫你補出缺少的 `updateTable()` IPC 處理邏輯？
+
+
+## ChatGPT 提問 串接前後端ts提示window.api錯誤
+ts 提示 window.api 錯誤，原生的 window 並沒有我們綁定的方法，該如何處理
+
+## ChatGPT 回答 串接前後端ts提示window.api錯誤
+你提到的 TypeScript 錯誤：
+
+> `Property 'api' does not exist on type 'Window & typeof globalThis'`
+
+這是因為 TypeScript 不知道你在 `preload.ts` 透過 `contextBridge.exposeInMainWorld('api', {...})` 綁定了一個 `window.api`。
+
+---
+
+### ✅ 解決方案：正確宣告 `window.api` 的型別
+
+你其實已經有一個 `src/mui.d.ts`，但這類型定義建議放在一個明確命名的檔案，例如 `src/preload.d.ts` 或 `src/global.d.ts`。
+
+---
+
+#### 🔧 步驟一：新增 `src/preload.d.ts`
+
+```ts
+// src/preload.d.ts
+export {};
+
+declare global {
+  interface Window {
+    api: {
+      uploadTable: (
+        tableInfo: { name: string; description?: string },
+        content: Record<string, any>[]
+      ) => Promise<void>;
+      getAllTableInfos: () => Promise<any[]>;
+      getTable: (id: number) => Promise<{
+        name: string;
+        rows: Record<string, any>[];
+      }>;
+      deleteTable: (id: number) => Promise<void>;
+      uploadChart: (
+        chartInfo: { name: string; description?: string },
+        config: unknown
+      ) => Promise<void>;
+      deleteChart: (id: number) => Promise<void>;
+      // 可擴充更多 IPC 方法，如 updateTable...
+      updateTable?: (
+        id: number,
+        name: string,
+        data: Record<string, any>[]
+      ) => Promise<void>;
+    };
+  }
+}
+```
+
+這樣，TypeScript 編譯器就能識別 `window.api`，不再報錯。
+
+---
+
+#### 🔧 步驟二：確認 `tsconfig.json` 有包含這個檔案
+
+一般情況下，只要 `preload.d.ts` 放在 `src/` 裡面，且你有設定：
+
+```json
+{
+  "compilerOptions": {
+    "types": ["vite/client"] // optional, 可保留
+  },
+  "include": ["src"]
+}
+```
+
+就會自動讀取 `global.d.ts` 或 `preload.d.ts` 中的 global 宣告。
+
+如果你把這個檔案放在 `electron/` 之外的 `src/`，通常是沒問題的。
+
+---
+
+#### 💡 小技巧：模組化方式也可行
+
+如果你有很多 API，可以這樣拆成 interface：
+
+```ts
+interface DataTableAPI {
+  uploadTable: (
+    tableInfo: { name: string; description?: string },
+    content: Record<string, any>[]
+  ) => Promise<void>;
+  getAllTableInfos: () => Promise<any[]>;
+  getTable: (id: number) => Promise<{
+    name: string;
+    rows: Record<string, any>[];
+  }>;
+  deleteTable: (id: number) => Promise<void>;
+  updateTable?: (
+    id: number,
+    name: string,
+    data: Record<string, any>[]
+  ) => Promise<void>;
+}
+
+interface ChartAPI {
+  uploadChart: (
+    chartInfo: { name: string; description?: string },
+    config: unknown
+  ) => Promise<void>;
+  deleteChart: (id: number) => Promise<void>;
+}
+
+declare global {
+  interface Window {
+    api: DataTableAPI & ChartAPI;
+  }
+}
+```
+
+---
+
+### ✅ 最終效果
+
+現在你在任一檔案都能安心使用：
+
+```ts
+const tables = await window.api.getAllTableInfos();
+await window.api.uploadTable({ name: "測試表格" }, [{ a: 1, b: 2 }]);
+```
+
+---
+
+如有使用 ESLint/TSLint 的話，也可以在此加上 `/* global window */` 或在設定中允許 global augmentation，但通常這樣寫就夠了。
+
+---
+
+需要我幫你補出 `updateTable` 的後端實作嗎？還是你想先試接前端？
+
+
 ## ChatGPT 提問 
 ## ChatGPT 回答 
 ## ChatGPT 提問 

--- a/docs/專案提示詞紀錄/專案提示詞紀錄-11.md
+++ b/docs/專案提示詞紀錄/專案提示詞紀錄-11.md
@@ -1,0 +1,888 @@
+## Gemini+ChatGPT 提問 DataTableEditorPage三種模式
+> 開新一頁
+你是一名專業的全端桌面軟體程式設計師，有多年使用 Electron + React 的豐富經驗，現在面對以下專案和問題
+
+🧩 專案背景：
+- 使用技術：
+  - 前端 Vite + React + MUI + Zustand + TypeScript
+  - 後端 Electron + better-sqlite3
+- 專案類型：資料視覺化儀表板
+- 目前架構：
+```front end
+  src/
+  ├── assets/data.json, snake.jpg
+  ├── components/common/ConfirmCancelButtons.tsx, DataTable.tsx, EditableCell.tsx, EditableTitle.tsx, Logo.tsx, PageHeader.tsx, SimpleTable.tsx
+  ├── components/DataTablesPage/DataTableList.tsx, UploadDataTableDialog.tsx
+  ├── components/layout/Breadcrumb.tsx, layout.css, Layout.tsx, PageWrapper.tsx, RightPanel.tsx, Sidebar.tsx, TocList.tsx, TocListItem.tsx, TopNav.tsx
+  ├── context/LayoutContext.tsx, LayoutProvider.tsx, useLayoutContext.tsx
+  ├── hooks/useFileParser.tsx, useTableEditor.tsx
+  ├── pages/ChartEditorPage.tsx, ChartsPage.tsx, ChartViewPage.tsx, DashboardPage.tsx, DashboardsPage.tsx, DataTableEditorPage.tsx, DataTablesPage.tsx, DownloadPage.tsx, HomePage.tsx, TestingPage.tsx, UploadPage.tsx
+  ├── stores/layoutStore.ts
+  ├── theme/index.ts
+  ├── App.tsx
+  ├── main.tsx
+  ├── mui.d.ts
+  ├── types.tsx
+  ├── utils.tsx
+  └── vite-env.d.ts
+```
+```backend
+  electron/
+  ├── ipc/APIModule.cts, ChartAPIHandlers.cts, DashboardAPIHandlers.cts, DataTableAPIHandlers.cts
+  ├── models/ChartManager.cts, DatabaseManager.cts, DataTableManager.cts, FileManager.cts
+  ├── node_modules/.tmp/tsconfig.electron.tsbuildinfo
+  ├── services/DataTableService.cts
+  ├── windows/mainWindow.cts
+  ├── constants.cts
+  ├── main.cts
+  ├── preload.cts
+  ├── tsconfig.json
+  ├── types.cts
+  └── utils.cts
+```
+
+🧱 已完成項目：
+- ipc: 綁定 DataTable 資料表相關 API
+- 使用 PageWrapper 完成排版相關的包裝
+
+🔧 目前狀態：
+- useTableGetter 建立自定義 Hook 來處理從後端 API 獲取資料表格邏輯
+- useFileParser 建立自定義 Hook 來處理資料表格檔案解析邏輯
+- 尚未實現新建立空白表格
+
+❓接下來想處理的問題：
+對於"從後端 API 獲取資料表格"、"使用者上傳資料表格檔案"、"使用者建立空白資料表格"三種模式，是否要使用單一的表格編輯頁面 DataTableEditorPage 對接，還是要分開寫成三個不同的頁面。請給出專業的優劣分析。
+
+相關檔案：
+```tsx
+// src/pages/DataTableEditorPage.tsx
+import React, { useEffect, useState } from "react";
+import { useLocation, useNavigate } from "react-router-dom";
+import { Box, Typography, CircularProgress, Alert } from "@mui/material";
+import { PageWrapper } from "../components/layout/PageWrapper";
+import EditableTitle from "../components/common/EditableTitle";
+import ConfirmCancelButtons from "../components/common/ConfirmCancelButtons";
+import DataTable from "../components/common/DataTable";
+import PageHeader from "../components/common/PageHeader";
+import { useFileParser } from "../hooks/useFileParser";
+import { useTableEditor } from "../hooks/useTableEditor";
+import { useTableGetter } from "src/hooks/useTableGetter";
+
+export const DataTableEditorPage: React.FC = () => {
+  const location = useLocation();
+  const navigate = useNavigate();
+  const editorMode: "create" | "edit" | "upload" | null =
+    location.state?.editorMode || null;
+  const tableId: number | undefined = location.state?.tableId;
+  const newTable: boolean = location.state?.newTable || false;
+  const file: File | null = location.state?.file || null;
+  const [disabled, setDisabled] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  // 使用自定義 hooks
+  const {
+    loading: tableGettedLoading,
+    info: tableGettedInfo,
+    data: tableGettedData,
+    error: tableGettedError,
+  } = useTableGetter(tableId);
+  const {
+    loading: fileParsedLoading,
+    data: fileParsedData,
+    error: fileParsedError,
+  } = useFileParser(file);
+  const {
+    tableName,
+    setTableName,
+    isEditingName,
+    setIsEditingName,
+    data,
+    handleCellChange,
+    updateData,
+  } = useTableEditor(null, file?.name.split(".")[0] || "未命名表格");
+
+  console.log("DataTableEditorPage:", location.state, fileParsedData);
+  // 當解析完成時更新資料
+  useEffect(() => {
+    if (editorMode === "edit") {
+      // 若有 id，從後端載入
+      setTableName(tableGettedInfo?.name || "未命名表格");
+      updateData(tableGettedData);
+    } else if (editorMode === "upload") {
+      // 否則從上傳的檔案解析
+      updateData(fileParsedData);
+    }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [tableId, tableGettedInfo, tableGettedData, fileParsedData]);
+
+  const handleTitleChange = (title: string) => {
+    setTableName(title);
+    if (!title.trim()) {
+      setDisabled(true);
+    } else {
+      setDisabled(false);
+    }
+  };
+
+  const handleConfirm = async () => {
+    if (!data) return;
+    if (!tableName.trim()) {
+      alert("請輸入表格名稱");
+      return;
+    }
+    if (error) {
+      alert("無法儲存有錯誤的表格");
+      return;
+    }
+    if (tableId) {
+      console.log(`確認並更新表格: ${tableName}`);
+      const dataTableWithInfo = await window.api.updateTable(
+        tableId,
+        tableName,
+        data
+      );
+      console.log("更新成功:", dataTableWithInfo);
+    } else {
+      console.log(`確認並儲存表格: ${tableName}`);
+      // 這裡可以加入儲存資料到後端的邏輯
+      const tableInfo = { name: tableName, description: "" };
+      const dataTableInfo = await window.api.uploadTable(tableInfo, data);
+      console.log("儲存成功:", dataTableInfo);
+    }
+    navigate("/data-tables");
+  };
+
+  const handleCancel = () => {
+    console.log("取消編輯");
+    navigate("/data-tables");
+  };
+
+  const renderContent = () => {
+    if (loading) return <CircularProgress />;
+    if (error) return <Alert severity="error">{error}</Alert>;
+    if (!data) return null;
+
+    return <DataTable data={data} onCellChange={handleCellChange} />;
+  };
+
+  const renderHeaderLeftContent = () => {
+    if (error) {
+      return (
+        <Box sx={{ display: "flex", alignItems: "center" }}>
+          <Typography variant="h4" sx={{ mr: 1, fontWeight: "bold" }}>
+            無檔案資料
+          </Typography>
+        </Box>
+      );
+    }
+
+    return (
+      <EditableTitle
+        title={tableName}
+        onTitleChange={handleTitleChange}
+        isEditing={isEditingName}
+        onEditingChange={setIsEditingName}
+        label="表格名稱"
+        placeholder="請輸入表格名稱"
+      />
+    );
+  };
+
+  const pageConfig = {
+    breadcrumbItems: [
+      { label: "資料表格管理", path: "/data-tables" },
+      { label: "編輯資料表格", path: "" },
+    ],
+    content: (
+      <Box sx={{ p: 3 }}>
+        <PageHeader
+          headerLeftContent={renderHeaderLeftContent()}
+          headerRightContent={
+            <ConfirmCancelButtons
+              onConfirm={handleConfirm}
+              onCancel={handleCancel}
+              showConfirm={!error}
+              disabled={disabled || loading || !!error || !data}
+            />
+          }
+        />
+        {renderContent()}
+      </Box>
+    ),
+    rightPanelContent: (
+      <Box sx={{ p: 2 }}>
+        <Typography variant="h6">編輯控制面板</Typography>
+        <Typography variant="body2" sx={{ mt: 1 }}>
+          這裡可以添加欄位類型、篩選、排序等控制項。
+        </Typography>
+      </Box>
+    ),
+  };
+
+  return <PageWrapper {...pageConfig} />;
+};
+```
+
+```tsx
+// src/hooks/useFileParser.ts
+import { useState, useEffect } from "react";
+import { getDataTableWithInfo, parseDataFile } from "../utils";
+import type {
+  DataTableHeaderSchema,
+  DataTableInfo,
+} from "shared/types/dataTable";
+
+interface useTableGetterReturn {
+  loading: boolean;
+  info: DataTableInfo | null;
+  data: DataTableHeaderSchema | null;
+  error: string | null;
+}
+
+export const useTableGetter = (
+  tableId: number | undefined
+): useTableGetterReturn => {
+  const [loading, setLoading] = useState(true);
+  const [info, setInfo] = useState<DataTableInfo | null>(null);
+  const [data, setData] = useState<DataTableHeaderSchema | null>(null);
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    const processFile = async () => {
+      if (!tableId) {
+        setError("無表格資料。請返回資料表格列表頁重新選擇。");
+        setLoading(false);
+        return;
+      }
+
+      try {
+        setLoading(true);
+        setError(null);
+        const dataTableWithInfo = await getDataTableWithInfo(tableId);
+        setInfo(dataTableWithInfo.info);
+        setData(dataTableWithInfo.data);
+      } catch (e: unknown) {
+        if (e instanceof Error) {
+          setError(e.message);
+        } else {
+          setError("取得表格時發生未知錯誤");
+        }
+      } finally {
+        setLoading(false);
+      }
+    };
+
+    processFile();
+  }, [tableId]);
+
+  return { loading, info, data, error };
+};
+```
+
+```tsx
+// src/hooks/useFileParser.ts
+import { useState, useEffect } from "react";
+import { parseDataFile } from "../utils";
+import type { DataTableHeaderSchema } from "shared/types/dataTable";
+
+interface UseFileParserReturn {
+  loading: boolean;
+  data: DataTableHeaderSchema | null;
+  error: string | null;
+}
+
+export const useFileParser = (file: File | null): UseFileParserReturn => {
+  const [loading, setLoading] = useState(true);
+  const [data, setData] = useState<DataTableHeaderSchema | null>(null);
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    const processFile = async () => {
+      if (!file) {
+        setError("無檔案資料。請返回資料表格列表頁重新上傳。");
+        setLoading(false);
+        return;
+      }
+
+      try {
+        setLoading(true);
+        setError(null);
+        const parsedData = await parseDataFile(file);
+        setData(parsedData);
+      } catch (e: unknown) {
+        if (e instanceof Error) {
+          setError(e.message);
+        } else {
+          setError("解析檔案時發生未知錯誤");
+        }
+      } finally {
+        setLoading(false);
+      }
+    };
+
+    processFile();
+  }, [file]);
+
+  return { loading, data, error };
+};
+```
+
+## Gemini 回答 DataTableEditorPage三種模式
+在分析這個問題時，我會從專業全端工程師的角度，考量開發效率、程式碼維護性、使用者體驗以及未來的擴展性。
+
+針對您提出的「使用單一頁面還是多個頁面來處理三種模式」，我的專業建議是：**使用單一的表格編輯頁面 (`DataTableEditorPage`) 來處理這三種模式，並搭配合理的狀態管理和自定義 Hook。**
+
+您目前的程式碼架構已經很好地體現了這個思路，接下來我會針對這個決策提供詳細的優劣分析。
+
+-----
+
+### 單一頁面方案的優劣分析
+
+**優點 (您的現有架構優勢)**
+
+  * **高內聚、低耦合：** 所有與表格編輯相關的邏輯和 UI 都集中在 `DataTableEditorPage`。這使得程式碼高度內聚，當需要修改表格編輯功能時，只需關注一個檔案。
+  * **程式碼重用性高：** 編輯表格的核心功能，例如表格渲染 (`DataTable`)、標題編輯 (`EditableTitle`)、資料變動處理 (`useTableEditor`)、儲存/取消按鈕 (`ConfirmCancelButtons`) 等，都可以在一個頁面內共用。這大大減少了重複程式碼，降低了開發和維護成本。
+  * **使用者體驗一致：** 無論使用者是上傳檔案、從後端載入或是建立空白表格，他們所看到的介面都是統一的。這種一致性讓使用者更容易上手，減少了學習曲線。
+  * **靈活且可擴展：** 您已使用了 `useLocation` 來傳遞不同的 `editorMode`，這是處理不同狀態的優雅方式。未來若有新的表格來源（例如從遠端 URL 載入），也只需在 `DataTableEditorPage` 中增加一個新的 `editorMode` 判斷即可，無需新增頁面。
+
+**缺點 (需要注意與最佳化的部分)**
+
+  * **邏輯複雜度：** 隨著模式的增加，單一頁面內的 `useEffect` 和條件渲染 (`if/else`) 邏輯會變得較為複雜。您已經使用了 `useTableGetter` 和 `useFileParser` 這兩個自定義 Hook 來處理資料獲取和解析，這是很好的做法，但仍需小心處理不同狀態之間的依賴關係，以免造成非預期的行為（例如重複載入）。
+  * **載入狀態處理：** 如您程式碼所示，您需要同時監控 `tableGettedLoading` 和 `fileParsedLoading` 兩個狀態。若不仔細處理，可能會出現載入狀態閃爍或邏輯混亂的問題。
+
+-----
+
+### 多個頁面方案的優劣分析
+
+**優點**
+
+  * **邏輯清晰：** 每個頁面只負責一個任務，例如 `DataTableUploadPage` 只處理上傳邏輯，`DataTableEditPage` 只處理編輯邏輯。這在初始階段可能會讓人覺得程式碼更清晰。
+
+**缺點**
+
+  * **程式碼高度重複：** 這是最大的問題。三個頁面將會有大量的重複程式碼，例如都包含 `DataTable`、`EditableTitle` 和 `ConfirmCancelButtons`。這會導致維護噩夢，當您需要修改表格編輯功能時，必須同步修改三個不同的檔案。
+  * **使用者體驗割裂：** 三個獨立的頁面可能會導致使用者在不同模式下感覺介面不一致，增加心智負擔。
+  * **難以維護與擴展：** 每次新增表格來源，都需要建立一個新的頁面。這會使專案變得龐大且難以管理。
+
+### 綜合結論與實作建議
+
+您目前的架構，即「**單一頁面 + 多個自定義 Hook**」是專業且正確的設計。它將核心功能抽離到獨立的 Hook 中，實現了**關注點分離** (Separation of Concerns)，同時又利用單一頁面保持了 UI 的一致性。
+
+為了進一步最佳化您目前的程式碼，這裡有幾點建議：
+
+1.  **統一載入狀態：** 您目前需要檢查 `tableGettedLoading` 和 `fileParsedLoading`。可以考慮在 `DataTableEditorPage` 中統一一個 `loading` 狀態，並根據 `editorMode` 來判斷：
+
+    ```jsx
+    const loading = (editorMode === 'edit' && tableGettedLoading) || (editorMode === 'upload' && fileParsedLoading);
+    ```
+
+2.  **處理 `useTableEditor` 的初始值：** 您目前在 `DataTableEditorPage` 中，將 `useTableEditor` 的初始資料設定為 `null`，然後再用 `useEffect` 來更新。這可能導致在資料載入完成之前，表格顯示為空。一個更好的做法是將資料來源作為參數傳遞給 `useTableEditor`。
+
+    ```jsx
+    // 在 DataTableEditorPage 中
+    const initialData = editorMode === 'edit' ? tableGettedData : fileParsedData;
+    const initialName = editorMode === 'upload' ? file?.name.split(".")[0] : tableGettedInfo?.name || "未命名表格";
+
+    const {
+      tableName,
+      setTableName,
+      data,
+      updateData,
+    } = useTableEditor(initialData, initialName);
+
+    // 這裡的 useEffect 就變得更簡單，主要用來處理載入狀態
+    useEffect(() => {
+        // 如果資料載入完成，但 useTableEditor 的狀態還沒更新，則更新它
+        // 注意：這裡需要處理好依賴關係，避免無限迴圈
+    }, [tableGettedData, fileParsedData]);
+    ```
+
+    這個邏輯需要您進一步思考如何設計 `useTableEditor`，使其能夠在不同模式下初始化。最理想的狀態是，`useTableEditor` 只負責管理**編輯狀態**，而**資料來源**的邏輯則完全由 `DataTableEditorPage` 處理。
+
+3.  **新增空白表格模式：** 您尚未實現「建立空白表格」的模式。只需在 `DataTableEditorPage` 中新增一個 `editorMode`，例如 `"create"`，並在這個模式下傳遞一個空的資料結構給 `useTableEditor` 即可。
+
+<!-- end list -->
+
+```jsx
+// 在 DataTableEditorPage 中
+const initialData = (() => {
+  if (editorMode === 'edit') return tableGettedData;
+  if (editorMode === 'upload') return fileParsedData;
+  if (editorMode === 'create') return { headers: ['Column 1', 'Column 2'], data: [['', '']] }; // 空白表格的初始資料
+  return null;
+})();
+
+const {
+  // ...
+  updateData,
+} = useTableEditor(initialData);
+
+```
+
+總結來說，您的選擇是正確的。堅持使用單一頁面，並透過狀態管理和自定義 Hook 來區分不同模式下的邏輯，這正是專業全端程式設計師會採用的方案。它兼顧了**開發效率、程式碼品質和使用者體驗**，為未來的專案擴展打下了堅實的基礎。
+
+您對目前的程式碼還有沒有其他想優化的部分呢？
+
+## ChatGPT 回答 DataTableEditorPage三種模式
+你的問題是：**是否應該將「新建空白表格」、「上傳表格檔案」、「編輯既有表格」三種情境共用同一個 `DataTableEditorPage`，還是拆分為三個不同的頁面？**
+
+這是一個典型的架構設計決策問題，以下我會從**專業角度分析共用與拆分的優缺點**，然後給出**建議與執行方案**。
+
+---
+
+### 🔍 這三種模式的核心差異
+
+| 模式         | 資料來源        | 是否已有 tableId | 是否需要初始化欄位資料 | 操作流程複雜度 |
+| ------------ | --------------- | ---------------- | ---------------------- | -------------- |
+| 新建空白表格 | 無 → 建立空表格 | 否               | ✅ 需要產生預設欄位     | 中             |
+| 上傳表格     | 檔案 → 解析檔案 | 否               | ❌ 無需初始化           | 高（處理異常） |
+| 編輯表格     | 後端 → 取資料   | ✅                | ❌ 無需初始化           | 低             |
+
+你目前的設計（共用 `DataTableEditorPage`）是正確且可行的，只要管理好狀態與資料初始化的流程，**不需要分頁**也能做到清晰可維護。
+
+---
+
+### ✅ 單一頁面（共用 `DataTableEditorPage`）的優缺點
+
+#### 優點：
+
+1. **可重用性高**：三種情境本質上都需要：
+
+   * 編輯表格名稱
+   * 呈現 `DataTable`
+   * 提交儲存 API
+2. **維護成本低**：共用邏輯集中在一個頁面，不會有邏輯分散問題。
+3. **使用狀態機式管理**可以保持清晰（`editorMode` 可作為主要狀態分支）。
+4. **UI/UX 一致性強**：對使用者來說是相同的編輯介面，符合直覺。
+
+#### 缺點：
+
+1. **進入頁面時資料初始化流程較複雜**，需要根據 `editorMode` 決定載入方式。
+2. **有些條件處理必須用 `if/else` 包裹在多個 `useEffect` 中，邏輯稍難閱讀。**
+3. **如果未來三種模式功能大幅分歧（例如上傳支援多表、多語言欄位處理等），將難以擴充**。
+
+---
+
+### ❌ 拆分為三個頁面的優缺點
+
+#### 優點：
+
+1. **每個頁面功能專一、邏輯清晰**：每個頁面只處理一種情境。
+2. **頁面生命週期與狀態更單純**，不用在單一頁面內處理多種來源與例外。
+3. **更容易針對特殊情境進行 UI 調整**，例如空白表格可以內建「新增欄位」的引導元件。
+
+#### 缺點：
+
+1. **大量程式碼重複**：三個頁面中 80% 邏輯會重疊（表格、儲存、錯誤處理等）。
+2. **維護成本高**：若共用邏輯要變更（例如表格格式、驗證邏輯），需改動三個頁面。
+3. **導航與使用體驗不一致**：可能會讓使用者在切換功能時感到混亂。
+
+---
+
+### ✅ 建議：繼續使用單一頁面，但使用「模式切換策略」優化可讀性與可維護性
+
+#### ✔ 建議架構設計方案
+
+1. **維持單一頁面**（`DataTableEditorPage`）作為統一入口。
+2. 使用 `editorMode` 做模式切換，保持目前的設計邏輯。
+3. 把以下邏輯分出去成單獨的 Hooks 或 Function Component 模組：
+
+   * `useEditTableInitializer(tableId)`
+   * `useUploadTableInitializer(file)`
+   * `useCreateTableInitializer()`
+4. 加入中介處理器（如 `initializeTableData()`）根據 mode 分配初始化邏輯，像這樣：
+
+```tsx
+useEffect(() => {
+  if (editorMode === "edit" && tableId) {
+    initEditTable(tableId);
+  } else if (editorMode === "upload" && file) {
+    initUploadTable(file);
+  } else if (editorMode === "create") {
+    initEmptyTable();
+  }
+}, [editorMode, tableId, file]);
+```
+
+---
+
+### 🧱 延伸建議：如何處理空白表格建立邏輯
+
+你目前還沒實作空白表格（create），可以新增一個 `initEmptyTable()`：
+
+```tsx
+const initEmptyTable = () => {
+  const defaultHeaders = [
+    { name: "欄位1", type: "string" },
+    { name: "欄位2", type: "number" },
+  ];
+  const defaultData = [
+    { "欄位1": "", "欄位2": 0 },
+    { "欄位1": "", "欄位2": 0 },
+  ];
+  setTableName("未命名表格");
+  updateData({ headers: defaultHeaders, rows: defaultData });
+};
+```
+
+---
+
+### ✍ 總結
+
+| 問題               | 建議                                                      |
+| ------------------ | --------------------------------------------------------- |
+| 要不要分頁？       | ❌ 不建議拆分，維持單一頁面是目前最佳選擇。                |
+| 如何簡化邏輯？     | ✅ 使用 `editorMode` 做切換，將初始化邏輯拆出去成小模組。  |
+| 如何實作空白表格？ | ✅ 內建一個預設欄位與資料的初始化函式 `initEmptyTable()`。 |
+
+這樣可以保持程式碼整潔、邏輯集中，還能未來擴充各種模式功能而不會變得混亂。
+
+如你需要，我也可以幫你抽出並實作這三個初始化 hook 模組。
+
+
+## Gemini 提問 DataTableEditorPage三種模式2
+請幫我重整 DataTableEditorPage 以及所需的 hooks
+
+## Gemini 回答 DataTableEditorPage三種模式2
+好的，我將根據我們的討論，為您重構 `DataTableEditorPage` 及其相關的自定義 Hook。
+
+重構的目標是：
+
+1.  **簡化 `DataTableEditorPage` 邏輯**：將狀態和邏輯推入 Hook 中，使頁面更專注於 UI 渲染。
+2.  **統一資料載入邏輯**：創建一個新的 Hook 來統一處理三種模式下的資料載入。
+3.  **優化 `useTableEditor`**：讓它能更靈活地處理不同的初始資料。
+
+### 重構後的前端架構
+
+```
+front end
+  src/
+  ├── ...
+  ├── hooks/
+  │   ├── useFileParser.tsx // 不變
+  │   ├── useTableEditor.tsx // 重構
+  │   ├── useTableGetter.tsx // 不變
+  │   └── useTableDataInitializer.tsx // 新增
+  ├── pages/
+  │   └── DataTableEditorPage.tsx // 重構
+  └── ...
+```
+
+-----
+
+### 1\. 新增 `useTableDataInitializer.tsx`
+
+這個新的 Hook 將專門負責處理根據 `editorMode` 來載入或初始化資料。它會整合 `useTableGetter` 和 `useFileParser` 的邏輯。
+
+```tsx
+// src/hooks/useTableDataInitializer.tsx
+import { useState, useEffect } from "react";
+import { useFileParser } from "./useFileParser";
+import { useTableGetter } from "./useTableGetter";
+import type { DataTableHeaderSchema } from "shared/types/dataTable";
+
+export interface DataTableState {
+  data: DataTableHeaderSchema | null;
+  name: string;
+  id?: number | null;
+}
+
+export const useTableDataInitializer = (
+  editorMode: "create" | "edit" | "upload" | null,
+  tableId?: number,
+  file?: File | null
+) => {
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+  const [initialState, setInitialState] = useState<DataTableState | null>(null);
+
+  const {
+    loading: tableGettedLoading,
+    info: tableGettedInfo,
+    data: tableGettedData,
+    error: tableGettedError,
+  } = useTableGetter(tableId);
+
+  const {
+    loading: fileParsedLoading,
+    data: fileParsedData,
+    error: fileParsedError,
+  } = useFileParser(file);
+
+  useEffect(() => {
+    const initializeData = () => {
+      setLoading(true);
+      setError(null);
+
+      if (editorMode === "edit" && !tableGettedLoading) {
+        if (tableGettedError) {
+          setError(tableGettedError);
+        } else if (tableGettedData) {
+          setInitialState({
+            data: tableGettedData,
+            name: tableGettedInfo?.name || "未命名表格",
+            id: tableId,
+          });
+        }
+        setLoading(false);
+      } else if (editorMode === "upload" && !fileParsedLoading) {
+        if (fileParsedError) {
+          setError(fileParsedError);
+        } else if (fileParsedData) {
+          setInitialState({
+            data: fileParsedData,
+            name: file?.name.split(".")[0] || "未命名表格",
+            id: null,
+          });
+        }
+        setLoading(false);
+      } else if (editorMode === "create") {
+        setInitialState({
+          data: { headers: ["Column 1"], data: [[]] },
+          name: "未命名表格",
+          id: null,
+        });
+        setLoading(false);
+      }
+    };
+
+    initializeData();
+  }, [
+    editorMode,
+    tableId,
+    file,
+    tableGettedLoading,
+    fileParsedLoading,
+    tableGettedData,
+    tableGettedInfo,
+    tableGettedError,
+    fileParsedData,
+    fileParsedError,
+  ]);
+
+  return { loading, error, initialState };
+};
+```
+
+-----
+
+### 2\. 重構 `useTableEditor.tsx`
+
+這個 Hook 的職責變得更單純：**管理表格的編輯狀態**。它不再處理資料的載入，而是直接接收初始資料。
+
+```tsx
+// src/hooks/useTableEditor.tsx
+import { useState, useEffect } from "react";
+import type {
+  DataTableHeaderSchema,
+  DataTableHeader,
+  DataRow,
+  DataValue,
+} from "shared/types/dataTable";
+
+export const useTableEditor = (initialData: DataTableHeaderSchema | null, initialName: string) => {
+  const [tableName, setTableName] = useState(initialName);
+  const [isEditingName, setIsEditingName] = useState(false);
+  const [data, setData] = useState<DataTableHeaderSchema | null>(initialData);
+
+  useEffect(() => {
+    setData(initialData);
+  }, [initialData]);
+
+  useEffect(() => {
+    setTableName(initialName);
+  }, [initialName]);
+
+  const updateData = (newData: DataTableHeaderSchema | null) => {
+    setData(newData);
+  };
+
+  const handleCellChange = (
+    rowIndex: number,
+    colIndex: number,
+    newValue: DataValue
+  ) => {
+    if (!data) return;
+    const newData = {
+      ...data,
+      data: data.data.map((row: DataRow, i: number) =>
+        i === rowIndex
+          ? row.map((cell: DataValue, j: number) =>
+              j === colIndex ? newValue : cell
+            )
+          : row
+      ),
+    };
+    setData(newData);
+  };
+
+  const handleHeaderChange = (colIndex: number, newHeader: DataTableHeader) => {
+    if (!data) return;
+    const newHeaders = [...data.headers];
+    newHeaders[colIndex] = newHeader;
+    setData({ ...data, headers: newHeaders });
+  };
+
+  return {
+    tableName,
+    setTableName,
+    isEditingName,
+    setIsEditingName,
+    data,
+    updateData,
+    handleCellChange,
+    handleHeaderChange,
+  };
+};
+```
+
+-----
+
+### 3\. 重構 `DataTableEditorPage.tsx`
+
+頁面變得非常乾淨，它現在只負責**從 `useTableDataInitializer` 獲取初始資料**，然後將資料和邏輯**傳遞給 `useTableEditor` 和 UI 元件**。
+
+```tsx
+// src/pages/DataTableEditorPage.tsx
+import React, { useEffect } from "react";
+import { useLocation, useNavigate } from "react-router-dom";
+import { Box, CircularProgress, Alert } from "@mui/material";
+import { PageWrapper } from "../components/layout/PageWrapper";
+import EditableTitle from "../components/common/EditableTitle";
+import ConfirmCancelButtons from "../components/common/ConfirmCancelButtons";
+import DataTable from "../components/common/DataTable";
+import PageHeader from "../components/common/PageHeader";
+import { useTableEditor } from "../hooks/useTableEditor";
+import { useTableDataInitializer } from "../hooks/useTableDataInitializer";
+
+export const DataTableEditorPage: React.FC = () => {
+  const location = useLocation();
+  const navigate = useNavigate();
+
+  const editorMode: "create" | "edit" | "upload" | null =
+    location.state?.editorMode || null;
+  const tableId: number | undefined = location.state?.tableId;
+  const file: File | null = location.state?.file || null;
+
+  // 1. 使用新的 Hook 來統一處理資料初始化和載入狀態
+  const { loading, error, initialState } = useTableDataInitializer(
+    editorMode,
+    tableId,
+    file
+  );
+
+  // 2. 將初始資料傳遞給 useTableEditor
+  const {
+    tableName,
+    setTableName,
+    isEditingName,
+    setIsEditingName,
+    data,
+    handleCellChange,
+  } = useTableEditor(initialState?.data || null, initialState?.name || "未命名表格");
+
+  // 3. 將儲存邏輯獨立出來
+  const handleConfirm = async () => {
+    if (!data || !tableName.trim() || error) {
+      alert("無法儲存，請檢查表格名稱和資料。");
+      return;
+    }
+    try {
+      if (initialState?.id) {
+        console.log(`確認並更新表格: ${tableName}`);
+        await window.api.updateTable(initialState.id, tableName, data);
+        console.log("更新成功!");
+      } else {
+        console.log(`確認並儲存表格: ${tableName}`);
+        const tableInfo = { name: tableName, description: "" };
+        await window.api.uploadTable(tableInfo, data);
+        console.log("儲存成功!");
+      }
+      navigate("/data-tables");
+    } catch (e: unknown) {
+      console.error("儲存失敗:", e);
+      alert("儲存表格時發生錯誤。");
+    }
+  };
+
+  const handleCancel = () => {
+    console.log("取消編輯");
+    navigate("/data-tables");
+  };
+
+  const renderContent = () => {
+    if (loading) return <CircularProgress />;
+    if (error) return <Alert severity="error">{error}</Alert>;
+    if (!data) return <Alert severity="info">無可編輯的表格資料。</Alert>;
+
+    return <DataTable data={data} onCellChange={handleCellChange} />;
+  };
+
+  const renderHeaderLeftContent = () => (
+    <EditableTitle
+      title={tableName}
+      onTitleChange={setTableName}
+      isEditing={isEditingName}
+      onEditingChange={setIsEditingName}
+      label="表格名稱"
+      placeholder="請輸入表格名稱"
+    />
+  );
+
+  const pageConfig = {
+    breadcrumbItems: [
+      { label: "資料表格管理", path: "/data-tables" },
+      { label: "編輯資料表格", path: "" },
+    ],
+    content: (
+      <Box sx={{ p: 3 }}>
+        <PageHeader
+          headerLeftContent={renderHeaderLeftContent()}
+          headerRightContent={
+            <ConfirmCancelButtons
+              onConfirm={handleConfirm}
+              onCancel={handleCancel}
+              showConfirm={!error}
+              disabled={loading || !!error || !data || !tableName.trim()}
+            />
+          }
+        />
+        {renderContent()}
+      </Box>
+    ),
+    rightPanelContent: (
+      <Box sx={{ p: 2 }}>
+        {/* ... (這裡的內容不變) */}
+      </Box>
+    ),
+  };
+
+  return <PageWrapper {...pageConfig} />;
+};
+```
+
+-----
+
+### 重構後的好處
+
+  * **更清晰的職責劃分**：
+      * `useTableDataInitializer`：專門負責**獲取**不同來源的資料。
+      * `useTableEditor`：專門負責**管理**資料的編輯狀態。
+      * `DataTableEditorPage`：專門負責**組合** Hook 和 UI 元件。
+  * **更簡潔的頁面程式碼**：頁面邏輯大大減少，變得更易讀、易於維護。
+  * **更高的靈活性**：您可以輕鬆地在任何需要初始資料的元件中使用 `useTableDataInitializer`，也可以在任何需要編輯功能的元件中使用 `useTableEditor`，而無需擔心資料來源。
+
+這個重構方案讓您的專案架構更加穩固，同時也為未來增加更多功能（例如欄位類型設定、排序等）提供了清晰的擴展點。您覺得這樣的重構方向符合您的需求嗎？
+
+## ChatGPT 提問 
+## ChatGPT 回答 
+## ChatGPT 提問 
+## ChatGPT 回答 
+## ChatGPT 提問 
+## ChatGPT 回答 
+## ChatGPT 提問 
+## ChatGPT 回答 
+## ChatGPT 提問 
+## ChatGPT 回答 
+## ChatGPT 提問 
+## ChatGPT 回答 

--- a/electron/ipc/ChartAPIHandlers.cts
+++ b/electron/ipc/ChartAPIHandlers.cts
@@ -23,14 +23,12 @@ export const ChartAPIHandlers: Record<string, IpcMainListener> = {
     );
     const previewPath = FileManager.saveFile(chartDirectory, "preview.png", ""); // 空檔案占位
 
-    ChartManager.addChart({
+    return ChartManager.addChart({
       name,
       description,
       config_path: configPath,
       preview_path: previewPath,
     });
-
-    return { name, description, configPath, previewPath };
   },
   // 刪除圖表
   "delete-chart": (_event, id: number) => {

--- a/electron/ipc/DataTableAPIHandlers.cts
+++ b/electron/ipc/DataTableAPIHandlers.cts
@@ -4,6 +4,7 @@ import { IpcMainListener } from "../types.cjs";
 import {
   DataTableHeaderSchema,
   DataTableWithInfo,
+  TableId,
 } from "shared/types/dataTable";
 
 export const DataTableAPIHandlers: Record<string, IpcMainListener> = {
@@ -33,7 +34,7 @@ export const DataTableAPIHandlers: Record<string, IpcMainListener> = {
   // 取得所有資料表資訊
   "get-all-table-infos": () => DataTableManager.getAllTableInfos(),
   // 取得單一資料表
-  "get-table": (_event, id: number): DataTableWithInfo => {
+  "get-table": (_event, id: TableId): DataTableWithInfo => {
     const tableInfo = DataTableManager.getTableInfoById(id);
     if (!tableInfo) throw new Error("資料表不存在");
 
@@ -49,7 +50,7 @@ export const DataTableAPIHandlers: Record<string, IpcMainListener> = {
       id,
       name,
       data,
-    }: { id: number; name: string; data: DataTableHeaderSchema }
+    }: { id: TableId; name: string; data: DataTableHeaderSchema }
   ): DataTableWithInfo => {
     const tableInfo = DataTableManager.getTableInfoById(id);
     if (!tableInfo) throw new Error("資料表不存在");
@@ -64,7 +65,7 @@ export const DataTableAPIHandlers: Record<string, IpcMainListener> = {
     return { info: updatedTable, data };
   },
   // 刪除資料表
-  "delete-table": (_event, id: number) => {
+  "delete-table": (_event, id: TableId) => {
     const table = DataTableManager.getTableInfoById(id);
     if (!table) throw new Error("資料表不存在");
 

--- a/electron/ipc/DataTableAPIHandlers.cts
+++ b/electron/ipc/DataTableAPIHandlers.cts
@@ -1,7 +1,10 @@
 import { FileManager } from "../models/FileManager.cjs";
 import { DataTableManager } from "../models/DataTableManager.cjs";
 import { IpcMainListener } from "../types.cjs";
-import { DataTable, DataTableInfo } from "shared/types/dataTable";
+import {
+  DataTableHeaderSchema,
+  DataTableWithInfo,
+} from "shared/types/dataTable";
 
 export const DataTableAPIHandlers: Record<string, IpcMainListener> = {
   // 上傳資料表
@@ -10,7 +13,10 @@ export const DataTableAPIHandlers: Record<string, IpcMainListener> = {
     {
       tableInfo,
       content,
-    }: { tableInfo: { name: string; description?: string }; content: DataTable }
+    }: {
+      tableInfo: { name: string; description?: string };
+      content: DataTableHeaderSchema;
+    }
   ) => {
     const { name, description } = tableInfo;
     const directory = FileManager.getUserDataPath("tables");
@@ -27,17 +33,35 @@ export const DataTableAPIHandlers: Record<string, IpcMainListener> = {
   // 取得所有資料表資訊
   "get-all-table-infos": () => DataTableManager.getAllTableInfos(),
   // 取得單一資料表
-  "get-table": (
-    _event,
-    id: number
-  ): { info: DataTableInfo; data: DataTable } => {
+  "get-table": (_event, id: number): DataTableWithInfo => {
     const tableInfo = DataTableManager.getTableInfoById(id);
     if (!tableInfo) throw new Error("資料表不存在");
 
     const content = FileManager.readFile(tableInfo.file_path);
-    const data: DataTable = JSON.parse(content);
+    const data: DataTableHeaderSchema = JSON.parse(content);
 
     return { info: tableInfo, data };
+  },
+  // 更新資料表
+  "update-table": (
+    _event,
+    {
+      id,
+      name,
+      data,
+    }: { id: number; name: string; data: DataTableHeaderSchema }
+  ): DataTableWithInfo => {
+    const tableInfo = DataTableManager.getTableInfoById(id);
+    if (!tableInfo) throw new Error("資料表不存在");
+
+    // 更新檔案內容
+    FileManager.saveFileWithPath(tableInfo.file_path, data);
+
+    // 更新資料表資訊
+    const updatedTable = DataTableManager.updateTableInfo({ id, name });
+    if (!updatedTable) throw new Error("資料表更新失敗");
+
+    return { info: updatedTable, data };
   },
   // 刪除資料表
   "delete-table": (_event, id: number) => {

--- a/electron/models/DataTableManager.cts
+++ b/electron/models/DataTableManager.cts
@@ -1,4 +1,4 @@
-import { DataTableInfo } from "shared/types/dataTable";
+import { DataTableInfo, TableId } from "shared/types/dataTable";
 import { DatabaseManager } from "../models/DatabaseManager.cjs";
 
 export const DataTableManager = {
@@ -17,7 +17,7 @@ export const DataTableManager = {
       "SELECT id, name, description, file_path, created_at, updated_at FROM tables"
     );
   },
-  getTableInfoById: (id: number): DataTableInfo | undefined => {
+  getTableInfoById: (id: TableId): DataTableInfo | undefined => {
     return DatabaseManager.get<DataTableInfo>(
       "SELECT id, name, description, file_path, created_at, updated_at FROM tables WHERE id = ?",
       [id]
@@ -41,7 +41,7 @@ export const DataTableManager = {
     return DataTableManager.getTableInfoById(result.lastInsertRowid as number)!; // 驚嘆號是 ts 標註，表示不可能是 undefined 或 null
   },
   updateTableInfo: (info: {
-    id: number;
+    id: TableId;
     name?: string;
     description?: string;
     file_path?: string;
@@ -68,7 +68,7 @@ export const DataTableManager = {
     DatabaseManager.run(sql, values);
     return DataTableManager.getTableInfoById(info.id)!;
   },
-  deleteTableInfo: (id: number): void => {
+  deleteTableInfo: (id: TableId): void => {
     DatabaseManager.run("DELETE FROM tables WHERE id = ?", [id]);
   },
 };

--- a/electron/models/FileManager.cts
+++ b/electron/models/FileManager.cts
@@ -34,6 +34,9 @@ export const FileManager = {
     fs.writeFileSync(filePath, JSON.stringify(content));
     return filePath;
   },
+  saveFileWithPath: (filePath: string, content: unknown) => {
+    fs.writeFileSync(filePath, JSON.stringify(content));
+  },
 
   // 讀取檔案
   readFile: (filePath: string) => {
@@ -56,5 +59,8 @@ export const FileManager = {
     const filePath = path.join(directory, fileName);
     fs.writeFileSync(filePath, imageBuffer);
     return filePath;
+  },
+  saveImageWithPath: (filePath: string, imageBuffer: Buffer) => {
+    fs.writeFileSync(filePath, imageBuffer);
   },
 };

--- a/electron/preload.cts
+++ b/electron/preload.cts
@@ -1,17 +1,101 @@
 console.log("Preload script loaded");
 import { contextBridge, ipcRenderer } from "electron";
+
+interface Message {
+  message: string;
+}
+type ColumnType = "string" | "number" | "boolean" | "date";
+interface ColumnInfo {
+  name: string;
+  desc?: string;
+  type: ColumnType;
+}
+
+interface DataTableInfo {
+  id: string;
+  name: string;
+  description?: string;
+  file_path: string;
+  created_at: string;
+  updated_at: string;
+  fileSize?: string | number;
+  columnInfos?: ColumnInfo[];
+}
+
+type DataType = string | number | boolean | null | undefined;
+// type DataRecord = Record<string, DataType>;
+type DataRow = DataType[];
+// type DataTableRecordSchema = DataRecord[];
+interface DataTableHeaderSchema {
+  headers: string[];
+  rows: DataRow[];
+}
+interface DataTableWithInfo {
+  info: DataTableInfo;
+  data: DataTableHeaderSchema;
+}
+
+interface ChartInfo {
+  id: number;
+  name: string;
+  description?: string;
+  config_path: string;
+  preview_path?: string;
+  created_at: string;
+  updated_at: string;
+}
+// interface ChartConfig {
+//   title: string;
+//   type: "bar" | "line" | "pie" | "scatter" | "histogram";
+//   xAxis: string;
+//   yAxis: string;
+//   series?: string[];
+//   options?: Record<string, unknown>;
+// }
+// interface ChartWithConfig {
+//   info: ChartInfo;
+//   config: ChartConfig;
+// }
+// interface ChartWithPreview extends ChartWithConfig {
+//   previewPath?: string;
+// }
+// interface ChartWithData extends ChartWithConfig {
+//   data: Record<string, unknown>[];
+// }
+// interface ChartWithDataAndPreview extends ChartWithData {
+//   previewPath?: string;
+// }
+// type ChartType =
+//   | ChartWithConfig
+//   | ChartWithData
+//   | ChartWithPreview
+//   | ChartWithDataAndPreview;
+// type ChartTypeName = ChartType["info"]["name"];
+
 contextBridge.exposeInMainWorld("api", {
   uploadTable: (
     tableInfo: { name: string; description?: string },
-    content: Record<string, string | number | boolean | null | undefined>[]
-  ) => ipcRenderer.invoke("upload-table", { tableInfo, content }),
-  getAllTableInfos: () => ipcRenderer.invoke("get-all-table-infos"),
-  getTable: (id: number) => ipcRenderer.invoke("get-table", id),
-  deleteTable: (id: number) => ipcRenderer.invoke("delete-table", id),
+    content: DataTableHeaderSchema
+  ): Promise<DataTableInfo> =>
+    ipcRenderer.invoke("upload-table", { tableInfo, content }),
+  getAllTableInfos: (): Promise<DataTableInfo[]> =>
+    ipcRenderer.invoke("get-all-table-infos"),
+  getTable: (id: number): Promise<DataTableWithInfo> =>
+    ipcRenderer.invoke("get-table", id),
+  updateTable: (
+    id: number,
+    name: string,
+    data: DataTableHeaderSchema
+  ): Promise<DataTableWithInfo> =>
+    ipcRenderer.invoke("update-table", { id, name, data }),
+  deleteTable: (id: number): Promise<Message> =>
+    ipcRenderer.invoke("delete-table", id),
   uploadChart: (
     chartInfo: { name: string; description?: string },
     config: unknown
-  ) => ipcRenderer.invoke("upload-chart", { chartInfo, config }),
-  deleteChart: (id: number) => ipcRenderer.invoke("delete-chart", id),
+  ): Promise<ChartInfo> =>
+    ipcRenderer.invoke("upload-chart", { chartInfo, config }),
+  deleteChart: (id: number): Promise<Message> =>
+    ipcRenderer.invoke("delete-chart", id),
 });
 console.log("Preload script end");

--- a/electron/preload.cts
+++ b/electron/preload.cts
@@ -1,76 +1,13 @@
 console.log("Preload script loaded");
 import { contextBridge, ipcRenderer } from "electron";
-
-interface Message {
-  message: string;
-}
-type ColumnType = "string" | "number" | "boolean" | "date";
-interface ColumnInfo {
-  name: string;
-  desc?: string;
-  type: ColumnType;
-}
-
-interface DataTableInfo {
-  id: string;
-  name: string;
-  description?: string;
-  file_path: string;
-  created_at: string;
-  updated_at: string;
-  fileSize?: string | number;
-  columnInfos?: ColumnInfo[];
-}
-
-type DataType = string | number | boolean | null | undefined;
-// type DataRecord = Record<string, DataType>;
-type DataRow = DataType[];
-// type DataTableRecordSchema = DataRecord[];
-interface DataTableHeaderSchema {
-  headers: string[];
-  rows: DataRow[];
-}
-interface DataTableWithInfo {
-  info: DataTableInfo;
-  data: DataTableHeaderSchema;
-}
-
-interface ChartInfo {
-  id: number;
-  name: string;
-  description?: string;
-  config_path: string;
-  preview_path?: string;
-  created_at: string;
-  updated_at: string;
-}
-// interface ChartConfig {
-//   title: string;
-//   type: "bar" | "line" | "pie" | "scatter" | "histogram";
-//   xAxis: string;
-//   yAxis: string;
-//   series?: string[];
-//   options?: Record<string, unknown>;
-// }
-// interface ChartWithConfig {
-//   info: ChartInfo;
-//   config: ChartConfig;
-// }
-// interface ChartWithPreview extends ChartWithConfig {
-//   previewPath?: string;
-// }
-// interface ChartWithData extends ChartWithConfig {
-//   data: Record<string, unknown>[];
-// }
-// interface ChartWithDataAndPreview extends ChartWithData {
-//   previewPath?: string;
-// }
-// type ChartType =
-//   | ChartWithConfig
-//   | ChartWithData
-//   | ChartWithPreview
-//   | ChartWithDataAndPreview;
-// type ChartTypeName = ChartType["info"]["name"];
+import type { Message } from "shared/types";
+import type {
+  DataTableHeaderSchema,
+  DataTableInfo,
+  DataTableWithInfo,
+  TableId,
+} from "shared/types/dataTable";
+import type { ChartInfo } from "shared/types/chart";
 
 contextBridge.exposeInMainWorld("api", {
   uploadTable: (
@@ -80,15 +17,15 @@ contextBridge.exposeInMainWorld("api", {
     ipcRenderer.invoke("upload-table", { tableInfo, content }),
   getAllTableInfos: (): Promise<DataTableInfo[]> =>
     ipcRenderer.invoke("get-all-table-infos"),
-  getTable: (id: number): Promise<DataTableWithInfo> =>
+  getTable: (id: TableId): Promise<DataTableWithInfo> =>
     ipcRenderer.invoke("get-table", id),
   updateTable: (
-    id: number,
+    id: TableId,
     name: string,
     data: DataTableHeaderSchema
   ): Promise<DataTableWithInfo> =>
     ipcRenderer.invoke("update-table", { id, name, data }),
-  deleteTable: (id: number): Promise<Message> =>
+  deleteTable: (id: TableId): Promise<Message> =>
     ipcRenderer.invoke("delete-table", id),
   uploadChart: (
     chartInfo: { name: string; description?: string },

--- a/shared/types/dataTable.ts
+++ b/shared/types/dataTable.ts
@@ -1,12 +1,14 @@
+export type SupportedFileType = "csv" | "json";
+export type FileType = SupportedFileType | "unknown";
 export type ColumnType = "string" | "number" | "boolean" | "date";
 export interface ColumnInfo {
   name: string;
   desc?: string;
   type: ColumnType;
 }
-
+export type TableId = string | number;
 export interface DataTableInfo {
-  id: string;
+  id: TableId;
   name: string;
   description?: string;
   file_path: string;

--- a/shared/types/dataTable.ts
+++ b/shared/types/dataTable.ts
@@ -16,12 +16,13 @@ export interface DataTableInfo {
   columnInfos?: ColumnInfo[];
 }
 
-export type DataType = string | number | boolean | null | undefined;
-export type DataRecord = Record<string, DataType>;
-export type DataRow = DataType[];
+export type DataValue = string | number | boolean | null | undefined;
+export type DataRecord = Record<string, DataValue>;
+export type DataRow = DataValue[];
 export type DataTableRecordSchema = DataRecord[];
+export type DataTableHeader = string;
 export interface DataTableHeaderSchema {
-  headers: string[];
+  headers: DataTableHeader[];
   rows: DataRow[];
 }
 export interface DataTableWithInfo {

--- a/shared/types/dataTable.ts
+++ b/shared/types/dataTable.ts
@@ -17,10 +17,14 @@ export interface DataTableInfo {
 }
 
 export type DataType = string | number | boolean | null | undefined;
-export type DataRow = Record<string, DataType>;
-export type DataTable = DataRow[];
-
+export type DataRecord = Record<string, DataType>;
+export type DataRow = DataType[];
+export type DataTableRecordSchema = DataRecord[];
+export interface DataTableHeaderSchema {
+  headers: string[];
+  rows: DataRow[];
+}
 export interface DataTableWithInfo {
   info: DataTableInfo;
-  data: DataTable;
+  data: DataTableHeaderSchema;
 }

--- a/shared/types/index.ts
+++ b/shared/types/index.ts
@@ -1,8 +1,6 @@
-export interface ParsedData {
-  headers: string[];
-  rows: (string | number)[][];
+export interface Message {
+  message: string;
 }
-
 export type Result<T, E> = Ok<T, E> | Err<T, E>;
 export class Ok<T, _> {
   readonly type = "ok" as const;

--- a/src/components/DataTablesPage/DataTableList.tsx
+++ b/src/components/DataTablesPage/DataTableList.tsx
@@ -19,9 +19,10 @@ import {
 } from "@mui/material";
 import MoreVertIcon from "@mui/icons-material/MoreVert";
 import { useState } from "react";
-import type { DataTableInfo } from "shared/types/dataTable";
+import type { DataTableInfo, TableId } from "shared/types/dataTable";
 import { DeleteWarningDialog } from "../common/DeleteWarningDialog";
 import { useNavigate } from "react-router-dom";
+import type { EditTableNavigateState } from "src/types";
 
 interface Props {
   dataTables: DataTableInfo[];
@@ -36,23 +37,27 @@ export const DataTableList = ({
   refreshTableInfos,
 }: Props) => {
   const [anchorEl, setAnchorEl] = useState<null | HTMLElement>(null);
-  const [selectedTableId, setSelectedTableId] = useState<
-    string | number | null
-  >(null);
+  const [selectedTableId, setSelectedTableId] = useState<TableId | null>(null);
   const [openDialog, setOpenDialog] = useState(false);
   const navigate = useNavigate();
 
   const handleTableClick = (
     _event: React.MouseEvent<HTMLElement>,
-    tableId: string | number
+    tableId: TableId
   ) => {
     console.log(`點擊了表格 ${tableId}`);
-    navigate("/data-tables/edit", { state: { tableId: tableId } });
+    const state: EditTableNavigateState = {
+      editorMode: "edit",
+      tableId: tableId,
+    };
+    navigate("/data-tables/edit", {
+      state,
+    });
   };
 
   const handleMenuClick = (
     event: React.MouseEvent<HTMLElement>,
-    tableId: string | number
+    tableId: TableId
   ) => {
     setAnchorEl(event.currentTarget);
     setSelectedTableId(tableId);

--- a/src/components/DataTablesPage/DataTableList.tsx
+++ b/src/components/DataTablesPage/DataTableList.tsx
@@ -19,20 +19,29 @@ import {
 import MoreVertIcon from "@mui/icons-material/MoreVert";
 import { useState } from "react";
 import type { DataTableInfo } from "shared/types/dataTable";
+import { DeleteWarningDialog } from "../common/DeleteWarningDialog";
 
 interface Props {
   dataTables: DataTableInfo[];
   // 新增 viewMode 屬性
   viewMode: "card" | "list";
+  refreshTableInfos: () => void;
 }
 
-export const DataTableList = ({ dataTables, viewMode }: Props) => {
+export const DataTableList = ({
+  dataTables,
+  viewMode,
+  refreshTableInfos,
+}: Props) => {
   const [anchorEl, setAnchorEl] = useState<null | HTMLElement>(null);
-  const [selectedTableId, setSelectedTableId] = useState<string | null>(null);
+  const [selectedTableId, setSelectedTableId] = useState<
+    string | number | null
+  >(null);
+  const [openDialog, setOpenDialog] = useState(false);
 
   const handleMenuClick = (
     event: React.MouseEvent<HTMLElement>,
-    tableId: string
+    tableId: string | number
   ) => {
     setAnchorEl(event.currentTarget);
     setSelectedTableId(tableId);
@@ -46,6 +55,22 @@ export const DataTableList = ({ dataTables, viewMode }: Props) => {
   const handleAction = (action: string) => {
     console.log(`對表格 ${selectedTableId} 執行操作: ${action}`);
     handleMenuClose();
+  };
+
+  const closeDeleteDialog = () => {
+    setOpenDialog(false);
+    handleMenuClose();
+  };
+  const openDeleteDialog = () => {
+    setOpenDialog(true);
+    setAnchorEl(null);
+  };
+  const handleConfirmDelete = () => {
+    console.log(`刪除表格 ${selectedTableId}`);
+    window.api.deleteTable(selectedTableId!);
+    setOpenDialog(false);
+    handleMenuClose();
+    refreshTableInfos();
   };
 
   // 渲染列表的 Helper 函式
@@ -135,7 +160,6 @@ export const DataTableList = ({ dataTables, viewMode }: Props) => {
       ) : (
         <>{viewMode === "card" ? renderCards() : renderList()}</>
       )}
-
       {/* 單一表格操作選單 (保持不變) */}
       <Menu
         anchorEl={anchorEl}
@@ -146,8 +170,15 @@ export const DataTableList = ({ dataTables, viewMode }: Props) => {
         <MenuItem onClick={() => handleAction("編輯")}>編輯</MenuItem>
         <MenuItem onClick={() => handleAction("更新")}>更新</MenuItem>
         <MenuItem onClick={() => handleAction("下載")}>下載</MenuItem>
-        <MenuItem onClick={() => handleAction("刪除")}>刪除</MenuItem>
+        <MenuItem onClick={() => openDeleteDialog()}>刪除</MenuItem>
       </Menu>
+      <DeleteWarningDialog
+        title="刪除資料表格"
+        content="確定要刪除這個資料表格嗎？此操作無法復原。"
+        open={openDialog}
+        handleClose={closeDeleteDialog}
+        handleComfirm={handleConfirmDelete}
+      />
     </Box>
   );
 };

--- a/src/components/DataTablesPage/DataTableList.tsx
+++ b/src/components/DataTablesPage/DataTableList.tsx
@@ -15,11 +15,13 @@ import {
   TableHead,
   TableRow,
   Paper,
+  Link,
 } from "@mui/material";
 import MoreVertIcon from "@mui/icons-material/MoreVert";
 import { useState } from "react";
 import type { DataTableInfo } from "shared/types/dataTable";
 import { DeleteWarningDialog } from "../common/DeleteWarningDialog";
+import { useNavigate } from "react-router-dom";
 
 interface Props {
   dataTables: DataTableInfo[];
@@ -38,6 +40,15 @@ export const DataTableList = ({
     string | number | null
   >(null);
   const [openDialog, setOpenDialog] = useState(false);
+  const navigate = useNavigate();
+
+  const handleTableClick = (
+    _event: React.MouseEvent<HTMLElement>,
+    tableId: string | number
+  ) => {
+    console.log(`點擊了表格 ${tableId}`);
+    navigate("/data-tables/edit", { state: { tableId: tableId } });
+  };
 
   const handleMenuClick = (
     event: React.MouseEvent<HTMLElement>,
@@ -88,7 +99,11 @@ export const DataTableList = ({
         <TableBody>
           {dataTables.map((table) => (
             <TableRow key={table.id}>
-              <TableCell>{table.name}</TableCell>
+              <TableCell>
+                <Link onClick={(e) => handleTableClick(e, table.id)}>
+                  {table.name}
+                </Link>
+              </TableCell>
               <TableCell>{table.updated_at}</TableCell>
               <TableCell>{table.fileSize}</TableCell>
               <TableCell align="right">
@@ -122,7 +137,9 @@ export const DataTableList = ({
                   }}
                 >
                   <Typography variant="h6" component="div">
-                    {table.name}
+                    <Link onClick={(e) => handleTableClick(e, table.id)}>
+                      {table.name}
+                    </Link>
                   </Typography>
                   <IconButton
                     aria-label="more"

--- a/src/components/DataTablesPage/DataTableList.tsx
+++ b/src/components/DataTablesPage/DataTableList.tsx
@@ -183,8 +183,6 @@ export const DataTableList = ({
         open={Boolean(anchorEl)}
         onClose={handleMenuClose}
       >
-        <MenuItem onClick={() => handleAction("瀏覽")}>瀏覽</MenuItem>
-        <MenuItem onClick={() => handleAction("編輯")}>編輯</MenuItem>
         <MenuItem onClick={() => handleAction("更新")}>更新</MenuItem>
         <MenuItem onClick={() => handleAction("下載")}>下載</MenuItem>
         <MenuItem onClick={() => openDeleteDialog()}>刪除</MenuItem>

--- a/src/components/DataTablesPage/UploadDataTableDialog.tsx
+++ b/src/components/DataTablesPage/UploadDataTableDialog.tsx
@@ -17,6 +17,7 @@ import {
 import CloudUploadIcon from "@mui/icons-material/CloudUpload";
 import CloseIcon from "@mui/icons-material/Close";
 import { useNavigate } from "react-router-dom";
+import type { UploadTableNavigateState } from "src/types";
 
 interface Props {
   open: boolean;
@@ -71,7 +72,11 @@ export const UploadDataTableDialog = ({ open, onClose }: Props) => {
       if (selectedFiles.length === 1) {
         console.log("單一檔案上傳，導航至上傳資料表格頁面...");
         // 使用 navigate 傳遞 state
-        navigate("/data-tables/edit", { state: { file: selectedFiles[0] } });
+        const state: UploadTableNavigateState = {
+          editorMode: "upload",
+          file: selectedFiles[0],
+        };
+        navigate("/data-tables/edit", { state });
       } else {
         console.log("多個檔案上傳，返回資料表格列表頁...");
         // TODO : 多檔案上傳後的處理邏輯

--- a/src/components/DataTablesPage/UploadDataTableDialog.tsx
+++ b/src/components/DataTablesPage/UploadDataTableDialog.tsx
@@ -74,6 +74,7 @@ export const UploadDataTableDialog = ({ open, onClose }: Props) => {
         navigate("/data-tables/edit", { state: { file: selectedFiles[0] } });
       } else {
         console.log("多個檔案上傳，返回資料表格列表頁...");
+        // TODO : 多檔案上傳後的處理邏輯
         setSelectedFiles([]);
       }
     }, 2000);

--- a/src/components/common/ConfirmCancelButtons.tsx
+++ b/src/components/common/ConfirmCancelButtons.tsx
@@ -33,7 +33,7 @@ const ConfirmCancelButtons: React.FC<ConfirmCancelButtonsProps> = ({
         variant={cancelVariant}
         startIcon={<CancelIcon />}
         onClick={onCancel}
-        disabled={disabled}
+        // disabled={disabled}
       >
         {cancelText}
       </Button>

--- a/src/components/common/DataTable.tsx
+++ b/src/components/common/DataTable.tsx
@@ -12,10 +12,10 @@ import {
   Paper,
 } from "@mui/material";
 import EditableCell from "./EditableCell";
-import type { ParsedData } from "shared/types";
+import type { DataTableHeaderSchema } from "shared/types/dataTable";
 
 interface DataTableProps {
-  data: ParsedData;
+  data: DataTableHeaderSchema;
   onCellChange: (
     e: React.ChangeEvent<HTMLInputElement | HTMLTextAreaElement>,
     rowIndex: number,
@@ -69,7 +69,7 @@ const DataTable: React.FC<DataTableProps> = ({
                     key={cellIndex}
                     rowIndex={rowIndex}
                     colIndex={cellIndex}
-                    value={cell}
+                    value={String(cell)}
                     onChange={onCellChange}
                   />
                 ))}

--- a/src/components/common/DataTable.tsx
+++ b/src/components/common/DataTable.tsx
@@ -12,14 +12,14 @@ import {
   Paper,
 } from "@mui/material";
 import EditableCell from "./EditableCell";
-import type { DataTableHeaderSchema } from "shared/types/dataTable";
+import type { DataTableHeaderSchema, DataValue } from "shared/types/dataTable";
 
 interface DataTableProps {
   data: DataTableHeaderSchema;
   onCellChange: (
-    e: React.ChangeEvent<HTMLInputElement | HTMLTextAreaElement>,
     rowIndex: number,
-    colIndex: number
+    colIndex: number,
+    newValue: DataValue
   ) => void;
   title?: string;
   maxHeight?: string;

--- a/src/components/common/DeleteWarningDialog.tsx
+++ b/src/components/common/DeleteWarningDialog.tsx
@@ -1,3 +1,4 @@
+// src/components/common/DeleteWarningDialog.tsx
 import Button from "@mui/material/Button";
 import Dialog from "@mui/material/Dialog";
 import DialogActions from "@mui/material/DialogActions";

--- a/src/components/common/DeleteWarningDialog.tsx
+++ b/src/components/common/DeleteWarningDialog.tsx
@@ -1,0 +1,59 @@
+import Button from "@mui/material/Button";
+import Dialog from "@mui/material/Dialog";
+import DialogActions from "@mui/material/DialogActions";
+import DialogContent from "@mui/material/DialogContent";
+import DialogContentText from "@mui/material/DialogContentText";
+import DialogTitle from "@mui/material/DialogTitle";
+import IconButton from "@mui/material/IconButton";
+import CloseIcon from "@mui/icons-material/Close";
+
+interface DeleteWarningDialogProps {
+  title: string;
+  content: string;
+  open: boolean;
+  handleClose: () => void;
+  handleComfirm: () => void;
+}
+export const DeleteWarningDialog = ({
+  title,
+  content,
+  open,
+  handleClose,
+  handleComfirm,
+}: DeleteWarningDialogProps) => {
+  return (
+    <Dialog
+      open={open}
+      onClose={handleClose}
+      aria-labelledby="alert-dialog-title"
+      aria-describedby="alert-dialog-description"
+    >
+      <DialogTitle id="alert-dialog-title">{title}</DialogTitle>
+      <IconButton
+        aria-label="close"
+        onClick={handleClose}
+        sx={(theme) => ({
+          position: "absolute",
+          right: 8,
+          top: 8,
+          color: theme.palette.grey[500],
+        })}
+      >
+        <CloseIcon />
+      </IconButton>
+      <DialogContent>
+        <DialogContentText id="alert-dialog-description">
+          {content}
+        </DialogContentText>
+      </DialogContent>
+      <DialogActions>
+        <Button variant="outlined" onClick={handleClose} autoFocus>
+          取消
+        </Button>
+        <Button variant="contained" color="error" onClick={handleComfirm}>
+          刪除
+        </Button>
+      </DialogActions>
+    </Dialog>
+  );
+};

--- a/src/components/common/EditableCell.tsx
+++ b/src/components/common/EditableCell.tsx
@@ -1,16 +1,13 @@
 // src/components/common/EditableCell.tsx
 import React from "react";
 import { TableCell, TextField, Tooltip, Typography } from "@mui/material";
+import type { DataValue } from "shared/types/dataTable";
 type EditableCellProps = {
   rowIndex: number;
   colIndex: number;
   value: string | number;
   disabled?: boolean;
-  onChange: (
-    e: React.ChangeEvent<HTMLInputElement | HTMLTextAreaElement>,
-    rowIndex: number,
-    colIndex: number
-  ) => void;
+  onChange: (rowIndex: number, colIndex: number, newValue: DataValue) => void;
 };
 const EditableCell = React.memo<EditableCellProps>(
   ({ rowIndex, colIndex, value, onChange, disabled = false }) => {
@@ -36,7 +33,7 @@ const EditableCell = React.memo<EditableCellProps>(
         {isEditing ? (
           <TextField
             value={value}
-            onChange={(e) => onChange(e, rowIndex, colIndex)}
+            onChange={(e) => onChange(rowIndex, colIndex, e.target.value)}
             onBlur={() => setIsEditing(false)}
             autoFocus
             variant="standard"

--- a/src/components/common/SimpleTable.tsx
+++ b/src/components/common/SimpleTable.tsx
@@ -1,4 +1,4 @@
-// src/components/common/DataTable.tsx
+// src/components/common/SimpleTable.tsx
 import React from "react";
 import {
   Table,

--- a/src/hooks/useFileParser.tsx
+++ b/src/hooks/useFileParser.tsx
@@ -1,17 +1,17 @@
 // src/hooks/useFileParser.ts
 import { useState, useEffect } from "react";
 import { parseDataFile } from "../utils";
-import type { ParsedData } from "shared/types";
+import type { DataTableHeaderSchema } from "shared/types/dataTable";
 
 interface UseFileParserReturn {
   loading: boolean;
-  data: ParsedData | null;
+  data: DataTableHeaderSchema | null;
   error: string | null;
 }
 
 export const useFileParser = (file: File | null): UseFileParserReturn => {
   const [loading, setLoading] = useState(true);
-  const [data, setData] = useState<ParsedData | null>(null);
+  const [data, setData] = useState<DataTableHeaderSchema | null>(null);
   const [error, setError] = useState<string | null>(null);
 
   useEffect(() => {

--- a/src/hooks/useFileParser.tsx
+++ b/src/hooks/useFileParser.tsx
@@ -9,7 +9,9 @@ interface UseFileParserReturn {
   error: string | null;
 }
 
-export const useFileParser = (file: File | null): UseFileParserReturn => {
+export const useFileParser = (
+  file: File | null | undefined
+): UseFileParserReturn => {
   const [loading, setLoading] = useState(true);
   const [data, setData] = useState<DataTableHeaderSchema | null>(null);
   const [error, setError] = useState<string | null>(null);

--- a/src/hooks/useTableDataInitializer.tsx
+++ b/src/hooks/useTableDataInitializer.tsx
@@ -2,18 +2,18 @@
 import { useState, useEffect } from "react";
 import { useFileParser } from "./useFileParser";
 import { useTableGetter } from "./useTableGetter";
-import type { DataTableHeaderSchema } from "shared/types/dataTable";
+import type { DataTableHeaderSchema, TableId } from "shared/types/dataTable";
 import type { EditorMode } from "src/types";
 
 export interface DataTableState {
   data: DataTableHeaderSchema | null;
   name: string;
-  id?: number | null;
+  id?: TableId | null;
 }
 
 export const useTableDataInitializer = (
   editorMode: EditorMode,
-  tableId?: number,
+  tableId?: TableId,
   file?: File | null
 ) => {
   const [loading, setLoading] = useState(true);

--- a/src/hooks/useTableDataInitializer.tsx
+++ b/src/hooks/useTableDataInitializer.tsx
@@ -1,0 +1,88 @@
+// src/hooks/useTableDataInitializer.tsx
+import { useState, useEffect } from "react";
+import { useFileParser } from "./useFileParser";
+import { useTableGetter } from "./useTableGetter";
+import type { DataTableHeaderSchema } from "shared/types/dataTable";
+import type { EditorMode } from "src/types";
+
+export interface DataTableState {
+  data: DataTableHeaderSchema | null;
+  name: string;
+  id?: number | null;
+}
+
+export const useTableDataInitializer = (
+  editorMode: EditorMode,
+  tableId?: number,
+  file?: File | null
+) => {
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+  const [initialState, setInitialState] = useState<DataTableState | null>(null);
+
+  const {
+    loading: tableGettedLoading,
+    info: tableGettedInfo,
+    data: tableGettedData,
+    error: tableGettedError,
+  } = useTableGetter(tableId);
+
+  const {
+    loading: fileParsedLoading,
+    data: fileParsedData,
+    error: fileParsedError,
+  } = useFileParser(file);
+
+  useEffect(() => {
+    const initializeData = () => {
+      setLoading(true);
+      setError(null);
+
+      if (editorMode === "edit" && !tableGettedLoading) {
+        if (tableGettedError) {
+          setError(tableGettedError);
+        } else if (tableGettedData) {
+          setInitialState({
+            data: tableGettedData,
+            name: tableGettedInfo?.name || "未命名表格",
+            id: tableId,
+          });
+        }
+        setLoading(false);
+      } else if (editorMode === "upload" && !fileParsedLoading) {
+        if (fileParsedError) {
+          setError(fileParsedError);
+        } else if (fileParsedData) {
+          setInitialState({
+            data: fileParsedData,
+            name: file?.name.split(".")[0] || "未命名表格",
+            id: null,
+          });
+        }
+        setLoading(false);
+      } else if (editorMode === "create") {
+        setInitialState({
+          data: { headers: ["Column 1"], rows: [[]] },
+          name: "未命名表格",
+          id: null,
+        });
+        setLoading(false);
+      }
+    };
+
+    initializeData();
+  }, [
+    editorMode,
+    tableId,
+    file,
+    tableGettedLoading,
+    fileParsedLoading,
+    tableGettedData,
+    tableGettedInfo,
+    tableGettedError,
+    fileParsedData,
+    fileParsedError,
+  ]);
+
+  return { loading, error, initialState };
+};

--- a/src/hooks/useTableEditor.tsx
+++ b/src/hooks/useTableEditor.tsx
@@ -1,6 +1,10 @@
-// src/hooks/useTableEditor.ts
-import { useState, useCallback } from "react";
-import type { DataTableHeaderSchema } from "shared/types/dataTable";
+// src/hooks/useTableEditor.tsx
+import { useState, useEffect } from "react";
+import type {
+  DataTableHeaderSchema,
+  DataTableHeader,
+  DataValue,
+} from "shared/types/dataTable";
 
 interface UseTableEditorReturn {
   tableName: string;
@@ -9,39 +13,51 @@ interface UseTableEditorReturn {
   setIsEditingName: (editing: boolean) => void;
   data: DataTableHeaderSchema | null;
   handleCellChange: (
-    e: React.ChangeEvent<HTMLInputElement | HTMLTextAreaElement>,
     rowIndex: number,
-    colIndex: number
+    colIndex: number,
+    newValue: DataValue
   ) => void;
   updateData: (newData: DataTableHeaderSchema | null) => void;
+  handleHeaderChange: (colIndex: number, newHeader: DataTableHeader) => void;
 }
 
 export const useTableEditor = (
   initialData: DataTableHeaderSchema | null,
-  initialTableName: string
+  initialName: string
 ): UseTableEditorReturn => {
-  const [tableName, setTableName] = useState(initialTableName);
+  const [tableName, setTableName] = useState(initialName);
   const [isEditingName, setIsEditingName] = useState(false);
   const [data, setData] = useState<DataTableHeaderSchema | null>(initialData);
 
-  const handleCellChange = useCallback(
-    (
-      e: React.ChangeEvent<HTMLInputElement | HTMLTextAreaElement>,
-      rowIndex: number,
-      colIndex: number
-    ) => {
-      if (!data) return;
+  useEffect(() => {
+    setData(initialData);
+  }, [initialData]);
 
-      const newData = { ...data };
-      newData.rows[rowIndex][colIndex] = e.target.value;
-      setData(newData);
-    },
-    [data]
-  );
+  useEffect(() => {
+    setTableName(initialName);
+  }, [initialName]);
 
-  const updateData = useCallback((newData: DataTableHeaderSchema | null) => {
+  const updateData = (newData: DataTableHeaderSchema | null) => {
     setData(newData);
-  }, []);
+  };
+
+  const handleCellChange = (
+    rowIndex: number,
+    colIndex: number,
+    newValue: DataValue
+  ) => {
+    if (!data) return;
+    const newData = { ...data };
+    newData.rows[rowIndex][colIndex] = newValue;
+    setData(newData);
+  };
+
+  const handleHeaderChange = (colIndex: number, newHeader: DataTableHeader) => {
+    if (!data) return;
+    const newHeaders = [...data.headers];
+    newHeaders[colIndex] = newHeader;
+    setData({ ...data, headers: newHeaders });
+  };
 
   return {
     tableName,
@@ -49,7 +65,8 @@ export const useTableEditor = (
     isEditingName,
     setIsEditingName,
     data,
-    handleCellChange,
     updateData,
+    handleCellChange,
+    handleHeaderChange,
   };
 };

--- a/src/hooks/useTableEditor.tsx
+++ b/src/hooks/useTableEditor.tsx
@@ -1,28 +1,28 @@
 // src/hooks/useTableEditor.ts
 import { useState, useCallback } from "react";
-import type { ParsedData } from "shared/types";
+import type { DataTableHeaderSchema } from "shared/types/dataTable";
 
 interface UseTableEditorReturn {
   tableName: string;
   setTableName: (name: string) => void;
   isEditingName: boolean;
   setIsEditingName: (editing: boolean) => void;
-  data: ParsedData | null;
+  data: DataTableHeaderSchema | null;
   handleCellChange: (
     e: React.ChangeEvent<HTMLInputElement | HTMLTextAreaElement>,
     rowIndex: number,
     colIndex: number
   ) => void;
-  updateData: (newData: ParsedData | null) => void;
+  updateData: (newData: DataTableHeaderSchema | null) => void;
 }
 
 export const useTableEditor = (
-  initialData: ParsedData | null,
+  initialData: DataTableHeaderSchema | null,
   initialTableName: string
 ): UseTableEditorReturn => {
   const [tableName, setTableName] = useState(initialTableName);
   const [isEditingName, setIsEditingName] = useState(false);
-  const [data, setData] = useState<ParsedData | null>(initialData);
+  const [data, setData] = useState<DataTableHeaderSchema | null>(initialData);
 
   const handleCellChange = useCallback(
     (
@@ -39,7 +39,7 @@ export const useTableEditor = (
     [data]
   );
 
-  const updateData = useCallback((newData: ParsedData | null) => {
+  const updateData = useCallback((newData: DataTableHeaderSchema | null) => {
     setData(newData);
   }, []);
 

--- a/src/hooks/useTableGetter.tsx
+++ b/src/hooks/useTableGetter.tsx
@@ -1,0 +1,53 @@
+// src/hooks/useTableGetter.ts
+import { useState, useEffect } from "react";
+import { getDataTableWithInfo } from "../utils";
+import type {
+  DataTableHeaderSchema,
+  DataTableInfo,
+} from "shared/types/dataTable";
+
+interface useTableGetterReturn {
+  loading: boolean;
+  info: DataTableInfo | null;
+  data: DataTableHeaderSchema | null;
+  error: string | null;
+}
+
+export const useTableGetter = (
+  tableId: number | undefined
+): useTableGetterReturn => {
+  const [loading, setLoading] = useState(true);
+  const [info, setInfo] = useState<DataTableInfo | null>(null);
+  const [data, setData] = useState<DataTableHeaderSchema | null>(null);
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    const gettingDataTable = async () => {
+      if (!tableId) {
+        setError("無表格資料。請返回資料表格列表頁重新選擇。");
+        setLoading(false);
+        return;
+      }
+
+      try {
+        setLoading(true);
+        setError(null);
+        const dataTableWithInfo = await getDataTableWithInfo(tableId);
+        setInfo(dataTableWithInfo.info);
+        setData(dataTableWithInfo.data);
+      } catch (e: unknown) {
+        if (e instanceof Error) {
+          setError(e.message);
+        } else {
+          setError("取得表格時發生未知錯誤");
+        }
+      } finally {
+        setLoading(false);
+      }
+    };
+
+    gettingDataTable();
+  }, [tableId]);
+
+  return { loading, info, data, error };
+};

--- a/src/hooks/useTableGetter.tsx
+++ b/src/hooks/useTableGetter.tsx
@@ -4,6 +4,7 @@ import { getDataTableWithInfo } from "../utils";
 import type {
   DataTableHeaderSchema,
   DataTableInfo,
+  TableId,
 } from "shared/types/dataTable";
 
 interface useTableGetterReturn {
@@ -14,7 +15,7 @@ interface useTableGetterReturn {
 }
 
 export const useTableGetter = (
-  tableId: number | undefined
+  tableId: TableId | undefined
 ): useTableGetterReturn => {
   const [loading, setLoading] = useState(true);
   const [info, setInfo] = useState<DataTableInfo | null>(null);

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -1,3 +1,4 @@
+// src/main.tsx
 import React from "react";
 import ReactDOM from "react-dom/client";
 import App from "./App";

--- a/src/pages/DataTableEditorPage.tsx
+++ b/src/pages/DataTableEditorPage.tsx
@@ -10,13 +10,14 @@ import PageHeader from "../components/common/PageHeader";
 import { useTableEditor } from "../hooks/useTableEditor";
 import { useTableDataInitializer } from "../hooks/useTableDataInitializer.tsx";
 import type { EditorMode } from "src/types.tsx";
+import type { TableId } from "shared/types/dataTable.ts";
 
 export const DataTableEditorPage: React.FC = () => {
   const location = useLocation();
   const navigate = useNavigate();
 
   const editorMode: EditorMode = location.state?.editorMode || null;
-  const tableId: number | undefined = location.state?.tableId;
+  const tableId: TableId | undefined = location.state?.tableId;
   const file: File | null = location.state?.file || null;
 
   // 1. 使用新的 Hook 來統一處理資料初始化和載入狀態

--- a/src/pages/DataTableEditorPage.tsx
+++ b/src/pages/DataTableEditorPage.tsx
@@ -1,5 +1,5 @@
 // src/pages/DataTableEditorPage.tsx
-import React, { useEffect } from "react";
+import React, { useEffect, useState } from "react";
 import { useLocation, useNavigate } from "react-router-dom";
 import { Box, Typography, CircularProgress, Alert } from "@mui/material";
 import { PageWrapper } from "../components/layout/PageWrapper";
@@ -15,6 +15,7 @@ export const DataTableEditorPage: React.FC = () => {
   const navigate = useNavigate();
   const tableId: number | undefined = location.state?.tableId;
   const file: File | null = location.state?.file || null;
+  const [disabled, setDisabled] = useState(false);
 
   // 使用自定義 hooks
   const { loading, data: parsedData, error } = useFileParser(file);
@@ -28,6 +29,7 @@ export const DataTableEditorPage: React.FC = () => {
     updateData,
   } = useTableEditor(null, file?.name.split(".")[0] || "未命名表格");
 
+  console.log("DataTableEditorPage:", location.state, parsedData);
   // 當解析完成時更新資料
   useEffect(() => {
     if (tableId) {
@@ -40,7 +42,17 @@ export const DataTableEditorPage: React.FC = () => {
       // 否則從上傳的檔案解析
       updateData(parsedData);
     }
-  }, [parsedData, updateData, tableId, setTableName]);
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [tableId, parsedData]);
+
+  const handleTitleChange = (title: string) => {
+    setTableName(title);
+    if (!title.trim()) {
+      setDisabled(true);
+    } else {
+      setDisabled(false);
+    }
+  };
 
   const handleConfirm = async () => {
     if (!data) return;
@@ -97,7 +109,7 @@ export const DataTableEditorPage: React.FC = () => {
     return (
       <EditableTitle
         title={tableName}
-        onTitleChange={setTableName}
+        onTitleChange={handleTitleChange}
         isEditing={isEditingName}
         onEditingChange={setIsEditingName}
         label="表格名稱"
@@ -120,6 +132,7 @@ export const DataTableEditorPage: React.FC = () => {
               onConfirm={handleConfirm}
               onCancel={handleCancel}
               showConfirm={!error}
+              disabled={disabled || loading || !!error || !data}
             />
           }
         />

--- a/src/pages/DataTablesPage.tsx
+++ b/src/pages/DataTablesPage.tsx
@@ -1,5 +1,5 @@
 // src/pages/DataTablesPage.tsx
-import { useState } from "react";
+import { useEffect, useState } from "react";
 import {
   Box,
   Typography,
@@ -16,42 +16,23 @@ import { PageWrapper } from "../components/layout/PageWrapper";
 import type { PageConfig } from "../types";
 import { DataTableList } from "../components/DataTablesPage/DataTableList";
 import { UploadDataTableDialog } from "../components/DataTablesPage/UploadDataTableDialog";
-
-// 假資料，用於模擬從後端獲取的資料
-const fakeDataTableInfos = [
-  {
-    id: "1",
-    name: "銷售數據",
-    file_path: "ttt.ss.ddf",
-    created_at: "2023-10-26",
-    updated_at: "2023-10-26",
-    fileSize: "1.2 MB",
-  },
-  {
-    id: "2",
-    name: "客戶資訊",
-    file_path: "ttt.ss.ddf",
-    created_at: "2023-10-25",
-    updated_at: "2023-10-25",
-    fileSize: "800 KB",
-  },
-  {
-    id: "3",
-    name: "庫存報表",
-    file_path: "ttt.ss.ddf",
-    created_at: "2023-10-24",
-    updated_at: "2023-10-24",
-    fileSize: "3.5 MB",
-  },
-];
+import type { DataTableInfo } from "shared/types/dataTable";
 
 export const DataTablesPage = () => {
   const [searchText, setSearchText] = useState("");
   const [uploadDialogOpen, setUploadDialogOpen] = useState(false);
   const [viewMode, setViewMode] = useState<"card" | "list">("card");
+  const [tableInfos, setTableInfos] = useState<DataTableInfo[]>([]); // 真正從後端來的資料
+
+  useEffect(() => {
+    // 載入後端資料表資訊
+    window.api.getAllTableInfos().then((tables) => {
+      setTableInfos(tables);
+    });
+  }, []);
 
   // 根據搜尋關鍵字過濾資料
-  const filteredDataTables = fakeDataTableInfos.filter((table) =>
+  const filteredDataTables = tableInfos.filter((table) =>
     table.name.toLowerCase().includes(searchText.toLowerCase())
   );
 

--- a/src/pages/DataTablesPage.tsx
+++ b/src/pages/DataTablesPage.tsx
@@ -1,5 +1,6 @@
 // src/pages/DataTablesPage.tsx
 import { useEffect, useState } from "react";
+import { useNavigate } from "react-router-dom";
 import {
   Box,
   Typography,
@@ -11,18 +12,20 @@ import {
 } from "@mui/material";
 import FormatListBulletedIcon from "@mui/icons-material/FormatListBulleted";
 import AddIcon from "@mui/icons-material/Add";
+import UploadIcon from "@mui/icons-material/Upload";
 import GridViewIcon from "@mui/icons-material/GridView";
 import { PageWrapper } from "../components/layout/PageWrapper";
-import type { PageConfig } from "../types";
 import { DataTableList } from "../components/DataTablesPage/DataTableList";
 import { UploadDataTableDialog } from "../components/DataTablesPage/UploadDataTableDialog";
 import type { DataTableInfo } from "shared/types/dataTable";
+import type { CreateTableNavigateState, PageConfig } from "../types";
 
 export const DataTablesPage = () => {
   const [searchText, setSearchText] = useState("");
   const [uploadDialogOpen, setUploadDialogOpen] = useState(false);
   const [viewMode, setViewMode] = useState<"card" | "list">("card");
   const [tableInfos, setTableInfos] = useState<DataTableInfo[]>([]); // 真正從後端來的資料
+  const navigate = useNavigate();
   console.log("DataTablesPage");
 
   useEffect(() => {
@@ -49,6 +52,11 @@ export const DataTablesPage = () => {
     if (newViewMode !== null) {
       setViewMode(newViewMode);
     }
+  };
+
+  const handleNewTableClick = () => {
+    const state: CreateTableNavigateState = { editorMode: "create" };
+    navigate("/data-tables/edit", { state });
   };
 
   // 頁面配置
@@ -102,11 +110,21 @@ export const DataTablesPage = () => {
                 onChange={(e) => setSearchText(e.target.value)}
               />
             </Grid>
-            {/* 上傳按鈕 */}
+            {/* 新增表格按鈕 */}
             <Grid>
               <Button
                 variant="contained"
                 startIcon={<AddIcon />}
+                onClick={() => handleNewTableClick()}
+              >
+                新增資料表格
+              </Button>
+            </Grid>
+            {/* 上傳按鈕 */}
+            <Grid>
+              <Button
+                variant="contained"
+                startIcon={<UploadIcon />}
                 onClick={() => setUploadDialogOpen(true)}
               >
                 上傳資料表格

--- a/src/pages/DataTablesPage.tsx
+++ b/src/pages/DataTablesPage.tsx
@@ -23,13 +23,18 @@ export const DataTablesPage = () => {
   const [uploadDialogOpen, setUploadDialogOpen] = useState(false);
   const [viewMode, setViewMode] = useState<"card" | "list">("card");
   const [tableInfos, setTableInfos] = useState<DataTableInfo[]>([]); // 真正從後端來的資料
+  console.log("DataTablesPage");
 
   useEffect(() => {
     // 載入後端資料表資訊
+    refreshTableInfos();
+  }, []);
+
+  const refreshTableInfos = () => {
     window.api.getAllTableInfos().then((tables) => {
       setTableInfos(tables);
     });
-  }, []);
+  };
 
   // 根據搜尋關鍵字過濾資料
   const filteredDataTables = tableInfos.filter((table) =>
@@ -111,7 +116,11 @@ export const DataTablesPage = () => {
         </Grid>
 
         {/* 將 viewMode 作為 props 傳遞給 DataTableList */}
-        <DataTableList dataTables={filteredDataTables} viewMode={viewMode} />
+        <DataTableList
+          dataTables={filteredDataTables}
+          viewMode={viewMode}
+          refreshTableInfos={refreshTableInfos}
+        />
 
         {/* 上傳資料表格對話框 */}
         <UploadDataTableDialog

--- a/src/pages/TestingPage.tsx
+++ b/src/pages/TestingPage.tsx
@@ -1,4 +1,4 @@
-// src/pages/DashboardPage.tsx
+// src/pages/TestingPage.tsx
 import { Box, Typography } from "@mui/material";
 import { PageWrapper } from "../components/layout/PageWrapper";
 import { useLayoutContext } from "../context/useLayoutContext";

--- a/src/preload.d.ts
+++ b/src/preload.d.ts
@@ -1,0 +1,36 @@
+export {};
+import type {
+  DataTableHeaderSchema,
+  DataTableInfo,
+  DataTableWithInfo,
+} from "shared/types/dataTable";
+import type { Message } from "shared/types";
+import type { ChartInfo } from "shared/types/chart";
+interface DataTableAPI {
+  uploadTable: (
+    tableInfo: { name: string; description?: string },
+    content: DataTableHeaderSchema
+  ) => Promise<DataTableInfo>;
+  getAllTableInfos: () => Promise<DataTableInfo[]>;
+  getTable: (id: number) => Promise<DataTableWithInfo>;
+  deleteTable: (id: number) => Promise<Message>;
+  updateTable: (
+    id: number,
+    name: string,
+    data: DataTableHeaderSchema
+  ) => Promise<DataTableWithInfo>;
+}
+
+interface ChartAPI {
+  uploadChart: (
+    chartInfo: { name: string; description?: string },
+    config: unknown
+  ) => Promise<ChartInfo>;
+  deleteChart: (id: number) => Promise<Message>;
+}
+
+declare global {
+  interface Window {
+    api: DataTableAPI & ChartAPI;
+  }
+}

--- a/src/preload.d.ts
+++ b/src/preload.d.ts
@@ -1,6 +1,7 @@
 // src/preload.d.ts
 export {};
 import type {
+  TableId,
   DataTableHeaderSchema,
   DataTableInfo,
   DataTableWithInfo,
@@ -13,10 +14,10 @@ interface DataTableAPI {
     content: DataTableHeaderSchema
   ) => Promise<DataTableInfo>;
   getAllTableInfos: () => Promise<DataTableInfo[]>;
-  getTable: (id: string | number) => Promise<DataTableWithInfo>;
-  deleteTable: (id: string | number) => Promise<Message>;
+  getTable: (id: TableId) => Promise<DataTableWithInfo>;
+  deleteTable: (id: TableId) => Promise<Message>;
   updateTable: (
-    id: string | number,
+    id: TableId,
     name: string,
     data: DataTableHeaderSchema
   ) => Promise<DataTableWithInfo>;

--- a/src/preload.d.ts
+++ b/src/preload.d.ts
@@ -12,10 +12,10 @@ interface DataTableAPI {
     content: DataTableHeaderSchema
   ) => Promise<DataTableInfo>;
   getAllTableInfos: () => Promise<DataTableInfo[]>;
-  getTable: (id: number) => Promise<DataTableWithInfo>;
-  deleteTable: (id: number) => Promise<Message>;
+  getTable: (id: string | number) => Promise<DataTableWithInfo>;
+  deleteTable: (id: string | number) => Promise<Message>;
   updateTable: (
-    id: number,
+    id: string | number,
     name: string,
     data: DataTableHeaderSchema
   ) => Promise<DataTableWithInfo>;

--- a/src/preload.d.ts
+++ b/src/preload.d.ts
@@ -1,3 +1,4 @@
+// src/preload.d.ts
 export {};
 import type {
   DataTableHeaderSchema,

--- a/src/types.tsx
+++ b/src/types.tsx
@@ -17,3 +17,5 @@ export interface PageConfig {
   rightPanelContent?: React.ReactNode;
   content: React.ReactNode;
 }
+
+export type EditorMode = "create" | "edit" | "upload" | null;

--- a/src/types.tsx
+++ b/src/types.tsx
@@ -1,3 +1,5 @@
+import type { TableId } from "shared/types/dataTable";
+
 // src/types.tsx
 export interface TocItem {
   label: string;
@@ -24,7 +26,7 @@ export interface CreateTableNavigateState {
 }
 export interface EditTableNavigateState {
   editorMode: "edit";
-  tableId: number;
+  tableId: TableId;
 }
 export interface UploadTableNavigateState {
   editorMode: "upload";

--- a/src/types.tsx
+++ b/src/types.tsx
@@ -19,3 +19,19 @@ export interface PageConfig {
 }
 
 export type EditorMode = "create" | "edit" | "upload" | null;
+export interface CreateTableNavigateState {
+  editorMode: "create";
+}
+export interface EditTableNavigateState {
+  editorMode: "edit";
+  tableId: number;
+}
+export interface UploadTableNavigateState {
+  editorMode: "upload";
+  file: File;
+}
+export type DataTableNavigateState =
+  | CreateTableNavigateState
+  | EditTableNavigateState
+  | UploadTableNavigateState
+  | null;

--- a/src/utils.tsx
+++ b/src/utils.tsx
@@ -3,6 +3,7 @@ import Papa from "papaparse";
 import type {
   DataTableHeaderSchema,
   DataTableWithInfo,
+  TableId,
 } from "shared/types/dataTable";
 
 // 針對 PapaParse 的資料，定義一個更精確的型別
@@ -70,7 +71,7 @@ export const parseDataFile = (file: File): Promise<DataTableHeaderSchema> => {
 };
 
 export const getDataTableWithInfo = (
-  tableId: number
+  tableId: TableId
 ): Promise<DataTableWithInfo> => {
   return window.api.getTable(tableId);
 };

--- a/src/utils.tsx
+++ b/src/utils.tsx
@@ -1,6 +1,9 @@
 // src/utils.tsx
 import Papa from "papaparse";
-import type { DataTableHeaderSchema } from "shared/types/dataTable";
+import type {
+  DataTableHeaderSchema,
+  DataTableWithInfo,
+} from "shared/types/dataTable";
 
 // 針對 PapaParse 的資料，定義一個更精確的型別
 interface PapaResultRow {
@@ -64,4 +67,10 @@ export const parseDataFile = (file: File): Promise<DataTableHeaderSchema> => {
       reject(new Error("不支援的檔案類型。"));
     }
   });
+};
+
+export const getDataTableWithInfo = (
+  tableId: number
+): Promise<DataTableWithInfo> => {
+  return window.api.getTable(tableId);
 };

--- a/src/utils.tsx
+++ b/src/utils.tsx
@@ -1,13 +1,13 @@
 // src/utils.tsx
 import Papa from "papaparse";
-import type { ParsedData } from "shared/types";
+import type { DataTableHeaderSchema } from "shared/types/dataTable";
 
 // 針對 PapaParse 的資料，定義一個更精確的型別
 interface PapaResultRow {
   [key: string]: string | number;
 }
 
-export const parseDataFile = (file: File): Promise<ParsedData> => {
+export const parseDataFile = (file: File): Promise<DataTableHeaderSchema> => {
   return new Promise((resolve, reject) => {
     if (file.type === "text/csv") {
       // 在 PapaParse 的 .parse 方法中，使用泛型來指定資料型別


### PR DESCRIPTION
## New Features
* Added a "Add Table" button that redirects to a unified table editing page.
* Clicking a table name redirects to the edit page, passing the `tableId` in state.
* Supports loading and editing existing tables via the backend API.
* Added table update functionality and unified table structure with `DataTableHeaderSchema`.
* Added `updateTable` IPC processing logic and API to enable frontend table updates.
* Added `FileManager` related helper methods.

## Refactoring and Optimization
* Unified `DataTableEditorPage` page logic to support backend loading, file uploads, and future blank table additions.
* Removed duplicate type definitions in the `preload` script and imported them from `shared/types` instead.
* Introduced the `TableId` type, replacing `number` or `string|number` used in various places.
* Added `src/preload.d.ts` type definition file to resolve an issue with the TypeScript compiler reporting errors for `window.api`.

## Documentation Updates
* Added documentation for project prompts related to collaboration with AI.

## Other
* Removed the unused "View" and "Edit" menu items from `DataTableList`.

---

feat(data-tables, ui, types, preload): 統一編輯頁面並支援後端資料表載入/更新

## 功能新增
* 新增「新增資料表格」按鈕，點擊後可導頁至統一的表格編輯頁面。
* 點擊資料表格名稱即可跳轉至編輯頁面，並透過狀態傳遞 `tableId`。
* 支援透過後端 API 載入並編輯現有的資料表。
* 新增更新資料表功能，並統一資料表結構為 `DataTableHeaderSchema`。
* 新增 `updateTable` IPC 處理邏輯與接口，使前端能更新資料表。
* 新增 `FileManager` 相關輔助方法。

## 重構與優化
* 將 `DataTableEditorPage` 頁面邏輯統一，以支援從後端載入、上傳檔案、以及未來新增空白表格三種模式。
* 移除 `preload` 腳本中重複的型別定義，並改為從 `shared/types` 匯入。
* 引入 `TableId` 型別，取代原本在多處使用的 `number` 或 `string | number`。
* 新增 `src/preload.d.ts` 型別定義檔，解決 TypeScript 編譯器對 `window.api` 報錯的問題。

## 文件更新
* 新增與 AI 協作的專案提示詞紀錄文件。

## 其他
* 移除 `DataTableList` 中未使用的「瀏覽」與「編輯」選單項。