### PR TITLE
feat(layout, ui, docs): Supports right panel title and collapsibility, and updates documentation.

### DIFF
--- a/docs/網站架構總攬.md
+++ b/docs/網站架構總攬.md
@@ -251,3 +251,37 @@
   /logs           # 紀錄檔
     /[timestamp].log
 ```
+
+## 原始碼規劃
+```front end
+  src/
+  ├── assets/data.json, snake.jpg
+  ├── components/common/ConfirmCancelButtons.tsx, DataTable.tsx, EditableCell.tsx, EditableTitle.tsx, Logo.tsx, PageHeader.tsx, SimpleTable.tsx
+  ├── components/DataTablesPage/DataTableList.tsx, UploadDataTableDialog.tsx
+  ├── components/layout/Breadcrumb.tsx, layout.css, Layout.tsx, PageWrapper.tsx, RightPanel.tsx, Sidebar.tsx, TocList.tsx, TocListItem.tsx, TopNav.tsx
+  ├── context/LayoutContext.tsx, LayoutProvider.tsx, useLayoutContext.tsx
+  ├── hooks/useFileParser.tsx, useTableEditor.tsx
+  ├── pages/ChartEditorPage.tsx, ChartsPage.tsx, ChartViewPage.tsx, DashboardPage.tsx, DashboardsPage.tsx, DataTableEditorPage.tsx, DataTablesPage.tsx, DownloadPage.tsx, HomePage.tsx, TestingPage.tsx, UploadPage.tsx
+  ├── stores/layoutStore.ts
+  ├── theme/index.ts
+  ├── App.tsx
+  ├── main.tsx
+  ├── mui.d.ts
+  ├── types.tsx
+  ├── utils.tsx
+  └── vite-env.d.ts
+```
+```backend
+  electron/
+  ├── ipc/APIModule.cts, ChartAPIHandlers.cts, DashboardAPIHandlers.cts, DataTableAPIHandlers.cts
+  ├── models/ChartManager.cts, DatabaseManager.cts, DataTableManager.cts, FileManager.cts
+  ├── node_modules/.tmp/tsconfig.electron.tsbuildinfo
+  ├── services/DataTableService.cts
+  ├── windows/mainWindow.cts
+  ├── constants.cts
+  ├── main.cts
+  ├── preload.cts
+  ├── tsconfig.json
+  ├── types.cts
+  └── utils.cts
+```

--- a/src/components/DataTablesPage/UploadDataTableDialog.tsx
+++ b/src/components/DataTablesPage/UploadDataTableDialog.tsx
@@ -114,7 +114,19 @@ export const UploadDataTableDialog = ({ open, onClose }: Props) => {
 
   return (
     <Dialog open={open} onClose={handleCancel} maxWidth="sm" fullWidth>
-      <DialogTitle>上傳資料表格</DialogTitle>
+      <DialogTitle>上傳資料表格</DialogTitle>{" "}
+      <IconButton
+        aria-label="close"
+        onClick={handleCancel}
+        sx={(theme) => ({
+          position: "absolute",
+          right: 8,
+          top: 8,
+          color: theme.palette.grey[500],
+        })}
+      >
+        <CloseIcon />
+      </IconButton>
       <DialogContent dividers>
         <Typography variant="subtitle1" gutterBottom>
           上傳模式

--- a/src/components/layout/Layout.tsx
+++ b/src/components/layout/Layout.tsx
@@ -3,12 +3,9 @@ import { Outlet } from "react-router-dom";
 import { Sidebar } from "./Sidebar";
 import { TopNav } from "./TopNav";
 import { RightPanel } from "./RightPanel";
-import { useLayoutContext } from "../../context/useLayoutContext";
 import "./layout.css";
 
 export const Layout = () => {
-  const { rightPanelEnabled } = useLayoutContext();
-
   return (
     <div className="layout-container">
       <Sidebar />
@@ -19,7 +16,7 @@ export const Layout = () => {
         </div>
       </div>
 
-      {rightPanelEnabled && <RightPanel />}
+      <RightPanel />
     </div>
   );
 };

--- a/src/components/layout/PageWrapper.tsx
+++ b/src/components/layout/PageWrapper.tsx
@@ -5,15 +5,21 @@ import type { PageConfig } from "../../types";
 
 export const PageWrapper = ({
   breadcrumbItems,
+  rightPanelTitle,
   rightPanelContent,
   content,
 }: Omit<PageConfig, "tocItems">) => {
-  const { setBreadcrumbItems, setRightPanelContent, setRightPanelEnabled } =
-    useLayoutContext();
+  const {
+    setBreadcrumbItems,
+    setRightPanelTitle,
+    setRightPanelContent,
+    setRightPanelEnabled,
+  } = useLayoutContext();
 
   useEffect(() => {
     setBreadcrumbItems(breadcrumbItems);
-    if (rightPanelContent) {
+    if (rightPanelTitle || rightPanelContent) {
+      setRightPanelTitle(rightPanelTitle);
       setRightPanelContent(rightPanelContent);
       setRightPanelEnabled(true);
     } else {

--- a/src/components/layout/RightPanel.tsx
+++ b/src/components/layout/RightPanel.tsx
@@ -1,16 +1,57 @@
 // src/components/layout/RightPanel.tsx
+import IconButton from "@mui/material/IconButton";
+import LeftArrow from "@mui/icons-material/KeyboardDoubleArrowLeft";
+import CloseIcon from "@mui/icons-material/Close";
 import { useLayoutStore } from "../../stores/layoutStore";
 import "./layout.css";
 
 export const RightPanel = () => {
-  const { rightPanelEnabled, rightPanelTitle, rightPanelContent } =
-    useLayoutStore();
+  const {
+    rightPanelEnabled,
+    rightPanelTitle,
+    rightPanelContent,
+    setRightPanelEnabled,
+  } = useLayoutStore();
+  const handleOpen = () => {
+    setRightPanelEnabled(true);
+  };
 
-  if (!rightPanelEnabled) return null;
+  const handleClose = () => {
+    setRightPanelEnabled(false);
+  };
+
+  if (!rightPanelEnabled)
+    return (
+      <div className="right-panel-collapsed" onClick={handleOpen}>
+        <IconButton
+          aria-label="open"
+          sx={{
+            position: "absolute",
+            top: "50%",
+            right: 0,
+            transform: "translateY(-50%)",
+          }}
+        >
+          <LeftArrow />
+        </IconButton>
+      </div>
+    );
 
   return (
     <div className="right-panel">
-      <div className="right-panel-title">{rightPanelTitle}</div>
+      <div className="right-panel-title">{rightPanelTitle}</div>{" "}
+      <IconButton
+        aria-label="close"
+        onClick={handleClose}
+        sx={(theme) => ({
+          position: "absolute",
+          right: 8,
+          top: 8,
+          color: theme.palette.grey[500],
+        })}
+      >
+        <CloseIcon />
+      </IconButton>
       <div className="right-panel-content">{rightPanelContent}</div>
     </div>
   );

--- a/src/components/layout/RightPanel.tsx
+++ b/src/components/layout/RightPanel.tsx
@@ -3,9 +3,15 @@ import { useLayoutStore } from "../../stores/layoutStore";
 import "./layout.css";
 
 export const RightPanel = () => {
-  const { rightPanelEnabled, rightPanelContent } = useLayoutStore();
+  const { rightPanelEnabled, rightPanelTitle, rightPanelContent } =
+    useLayoutStore();
 
   if (!rightPanelEnabled) return null;
 
-  return <div className="right-panel">{rightPanelContent}</div>;
+  return (
+    <div className="right-panel">
+      <div className="right-panel-title">{rightPanelTitle}</div>
+      <div className="right-panel-content">{rightPanelContent}</div>
+    </div>
+  );
 };

--- a/src/components/layout/layout.css
+++ b/src/components/layout/layout.css
@@ -35,3 +35,15 @@
     border-left: 1px solid #ddd;
     padding: 16px;
 }
+
+.right-panel-title {
+    font-size: 18px;
+    font-weight: bold;
+    margin-bottom: 12px;
+}
+
+.right-panel-content {
+    overflow-y: auto;
+    max-height: calc(100vh - 60px - 32px);
+    /* Adjust for top nav and padding */
+}

--- a/src/pages/DataTableEditorPage.tsx
+++ b/src/pages/DataTableEditorPage.tsx
@@ -1,7 +1,7 @@
 // src/pages/DataTableEditorPage.tsx
 import React from "react";
 import { useLocation, useNavigate } from "react-router-dom";
-import { Box, Typography, CircularProgress, Alert } from "@mui/material";
+import { Box, CircularProgress, Alert } from "@mui/material";
 import { PageWrapper } from "../components/layout/PageWrapper";
 import EditableTitle from "../components/common/EditableTitle";
 import ConfirmCancelButtons from "../components/common/ConfirmCancelButtons";
@@ -109,13 +109,9 @@ export const DataTableEditorPage: React.FC = () => {
         {renderContent()}
       </Box>
     ),
+    rightPanelTitle: "編輯控制面板",
     rightPanelContent: (
-      <Box sx={{ p: 2 }}>
-        <Typography variant="h6">編輯控制面板</Typography>
-        <Typography variant="body2" sx={{ mt: 1 }}>
-          這裡可以添加欄位類型、篩選、排序等控制項。
-        </Typography>
-      </Box>
+      <Box sx={{ p: 2 }}>這裡可以添加欄位類型、篩選、排序等控制項。</Box>
     ),
   };
 

--- a/src/pages/TestingPage.tsx
+++ b/src/pages/TestingPage.tsx
@@ -51,9 +51,9 @@ export const TestingPage = () => {
           </Box>
         </div>
       }
+      rightPanelTitle="儀表板右側標題"
       rightPanelContent={
         <div>
-          <Typography variant="h6">儀表板右側內容</Typography>
           <p>這裡可以放圖表設定、說明、連結等。</p>
         </div>
       }

--- a/src/stores/layoutStore.ts
+++ b/src/stores/layoutStore.ts
@@ -4,6 +4,7 @@ import type { BreadcrumbItem, PageConfig } from "../types";
 
 export interface LayoutState extends Omit<PageConfig, "content" | "tocItems"> {
   setBreadcrumbItems: (items: BreadcrumbItem[]) => void;
+  setRightPanelTitle: (title: React.ReactNode | null) => void;
 
   setRightPanelContent: (content: React.ReactNode | null) => void;
 
@@ -14,6 +15,9 @@ export interface LayoutState extends Omit<PageConfig, "content" | "tocItems"> {
 export const useLayoutStore = create<LayoutState>((set) => ({
   breadcrumbItems: [],
   setBreadcrumbItems: (items) => set({ breadcrumbItems: items }),
+
+  rightPanelTitle: null,
+  setRightPanelTitle: (title) => set({ rightPanelTitle: title }),
 
   rightPanelContent: null,
   setRightPanelContent: (content) => set({ rightPanelContent: content }),

--- a/src/types.tsx
+++ b/src/types.tsx
@@ -16,6 +16,7 @@ export interface BreadcrumbItem {
 export interface PageConfig {
   tocItems: TocItem[];
   breadcrumbItems: BreadcrumbItem[];
+  rightPanelTitle?: React.ReactNode;
   rightPanelContent?: React.ReactNode;
   content: React.ReactNode;
 }


### PR DESCRIPTION
feat(layout, ui, docs): Supports right panel title and collapsibility, and updates documentation.

## Feature Additions
* Supports right panel title.
* Added `rightPanelTitle` to the `PageConfig` type and `layout` store.
* `PageWrapper` can set both title and content.
* `DataTableEditorPage` and `TestingPage` now pass `rightPanelTitle`.

## Refactoring and Optimization
* Improved `RightPanel`, adding collapse/expand functionality and title styling.
* Changed `Layout` to always render `RightPanel`, no longer relying on conditionals.
* Added a close button in the top right corner of the `UploadDataTableDialog` dialog box. Clicking it triggers `handleCancel` to close the dialog box.

## Documentation Updates
* Added a "Source Code Planning" section to `docs/Site Architecture Overview.md` to explain the directory structure of the front-end (src/) and back-end (electron/).

---

feat(layout, ui, docs): 支援右側面板標題與收合功能，並更新文件

## 功能新增
* 支援右側面板標題。
* 在 `PageConfig` 型別與 `layout` store 新增 `rightPanelTitle`。
* `PageWrapper` 可同時設定標題與內容。
* `DataTableEditorPage` 與 `TestingPage` 傳入 `rightPanelTitle`。

## 重構與優化
* 改善 `RightPanel`，加入收合/展開功能與標題樣式。
* `Layout` 改為永遠渲染 `RightPanel`，不再依條件判斷。
* 在 `UploadDataTableDialog` 對話框右上角新增關閉按鈕，點擊後觸發 `handleCancel` 以關閉對話框。

## 文件更新
* 在 `docs/網站架構總攬.md` 新增「原始碼規劃」章節，說明前端 (src/) 與後端 (electron/) 的目錄結構。