### PR TITLE
feat(ui, docs): improve RightPanel layout and add default fallback text

### DIFF
--- a/docs/專案提示詞紀錄/專案提示詞紀錄-11.md
+++ b/docs/專案提示詞紀錄/專案提示詞紀錄-11.md
@@ -874,8 +874,89 @@ export const DataTableEditorPage: React.FC = () => {
 
 這個重構方案讓您的專案架構更加穩固，同時也為未來增加更多功能（例如欄位類型設定、排序等）提供了清晰的擴展點。您覺得這樣的重構方向符合您的需求嗎？
 
-## ChatGPT 提問 
-## ChatGPT 回答 
+## Gemini 提問 右側面板按鈕位置
+這個按鈕我想放到右側中間，現在在右上角
+```tsx
+<div className="right-panel-collapsed" onClick={handleOpen}>
+  <IconButton aria-label="open" sx={{ top: 0, right: 0 }}>
+    <LeftArrow />
+  </IconButton>
+</div>
+```
+
+## Gemini 回答 右側面板按鈕位置
+你可以修改 `IconButton` 的 `sx` 屬性來將按鈕移到右側中間。`top: '50%'` 和 `transform: 'translateY(-50%)'` 的組合可以精確地將元素垂直置中。
+
+```jsx
+<div className="right-panel-collapsed" onClick={handleOpen}>
+  <IconButton
+    aria-label="open"
+    sx={{
+      position: 'absolute', // 使用絕對定位
+      top: '50%',          // 向上移動 50%
+      right: 0,            // 靠右對齊
+      transform: 'translateY(-50%)' // 透過 transform 向上微調自身高度的 50%
+    }}
+  >
+    <LeftArrow />
+  </IconButton>
+</div>
+```
+
+-----
+
+### **替代方案**
+
+如果 `IconButton` 外層的 `div` (`right-panel-collapsed`) 已經設定了定位（例如 `position: relative`），那麼你只需要調整 `IconButton` 的 `sx` 屬性即可。
+
+```jsx
+<div className="right-panel-collapsed" onClick={handleOpen}>
+  <IconButton
+    aria-label="open"
+    sx={{
+      position: 'absolute',
+      top: '50%',
+      right: 0,
+      transform: 'translateY(-50%)'
+    }}
+  >
+    <LeftArrow />
+  </IconButton>
+</div>
+```
+
+-----
+
+### **使用 Flexbox**
+
+另一個更現代且彈性的做法是使用 **Flexbox**。你可以調整父容器的 CSS 屬性，讓其內部元素自動對齊。
+
+首先，為 `right-panel-collapsed` 增加 Flexbox 相關的屬性：
+
+```css
+.right-panel-collapsed {
+  display: flex;
+  align-items: center; /* 垂直置中 */
+  justify-content: flex-end; /* 水平靠右 */
+}
+```
+
+接著，移除 `IconButton` 上的 `sx` 屬性，讓它繼承父容器的對齊設定：
+
+```jsx
+<div className="right-panel-collapsed" onClick={handleOpen}>
+  <IconButton aria-label="open">
+    <LeftArrow />
+  </IconButton>
+</div>
+```
+
+這種方法的好處是更易於維護，且在響應式設計中表現更好。
+
+-----
+
+請問你需要哪一種方案呢？
+
 ## ChatGPT 提問 
 ## ChatGPT 回答 
 ## ChatGPT 提問 

--- a/src/components/layout/RightPanel.tsx
+++ b/src/components/layout/RightPanel.tsx
@@ -23,15 +23,7 @@ export const RightPanel = () => {
   if (!rightPanelEnabled)
     return (
       <div className="right-panel-collapsed" onClick={handleOpen}>
-        <IconButton
-          aria-label="open"
-          sx={{
-            position: "absolute",
-            top: "50%",
-            right: 0,
-            transform: "translateY(-50%)",
-          }}
-        >
+        <IconButton aria-label="open">
           <LeftArrow />
         </IconButton>
       </div>

--- a/src/components/layout/RightPanel.tsx
+++ b/src/components/layout/RightPanel.tsx
@@ -39,7 +39,9 @@ export const RightPanel = () => {
 
   return (
     <div className="right-panel">
-      <div className="right-panel-title">{rightPanelTitle}</div>{" "}
+      <div className="right-panel-title">
+        {rightPanelTitle || "右側面板標題"}
+      </div>{" "}
       <IconButton
         aria-label="close"
         onClick={handleClose}
@@ -52,7 +54,7 @@ export const RightPanel = () => {
       >
         <CloseIcon />
       </IconButton>
-      <div className="right-panel-content">{rightPanelContent}</div>
+      <div className="right-panel-content">{rightPanelContent || "無內容"}</div>
     </div>
   );
 };

--- a/src/components/layout/layout.css
+++ b/src/components/layout/layout.css
@@ -36,6 +36,21 @@
     padding: 16px;
 }
 
+.right-panel-collapsed {
+    display: flex;
+    align-items: center;
+    /* 垂直置中 */
+    justify-content: flex-end;
+    /* 水平靠右 */
+    width: 40px;
+    background-color: #f0f0f0;
+}
+
+.right-panel-collapsed:hover {
+    background-color: #e0e0e0;
+    cursor: pointer;
+}
+
 .right-panel-title {
     font-size: 18px;
     font-weight: bold;


### PR DESCRIPTION
feat(ui, docs): improve RightPanel layout and add default fallback text

**Features**
* **Default Fallback Text**: The RightPanel now displays default text when `rightPanelTitle` or `rightPanelContent` are not provided. It will show "右側面板標題" for the title and "無內容" for the content.

**Refactoring & Optimization**
* **Layout Refactoring**: The layout of the `RightPanel`'s collapsed state has been refactored.
* **Flexbox**: The toggle button is now vertically centered and right-aligned using Flexbox.
* **Style Separation**: Inline `sx` styling has been removed from the `IconButton`, with the CSS rules moved to a dedicated stylesheet for better maintainability.

**Documentation**
* **New Doc Section**: A new section has been added to the project's documentation, detailing the use of Flexbox for vertical and horizontal alignment.

**Miscellaneous**
* **Improved User Experience**: A hover effect has been added to the collapsed `RightPanel` to enhance user experience.

---

feat(ui, docs): 改善 RightPanel 版面並新增預設文字

**功能新增**
* **預設文字：** 當 `rightPanelTitle` 為空時，會顯示「右側面板標題」；當 `rightPanelContent` 為空時，會顯示「無內容」.

**重構與優化**
* **版面重構：** 重構了 `RightPanel` 的收合狀態版面配置.
* **Flexbox 應用：** 採用 Flexbox 實現按鈕的垂直置中與靠右對齊，讓程式碼更具可讀性與維護性.
* **樣式分離：** 移除了 `IconButton` 上的內聯樣式 (`sx`)，將樣式統一移至 `layout.css` 檔案中，實現樣式與元件邏輯分離.

**文件更新**
* **開發紀錄：** 在開發文件 (`docs/專案提示詞紀錄/專案提示詞紀錄-11.md`) 中，新增了關於使用 Flexbox 解決 `RightPanel` 按鈕位置的討論與實施細節.

**其他**
* **使用者體驗：** 新增了 `RightPanel` 收合狀態的懸停（hover）效果，以提供更佳的使用體驗.