### PR TITLE
feat(upload, dataTable, ui, store, types): add upload management flow with status panel and prevent duplicate table creation

### DIFF
--- a/docs/專案提示詞紀錄/專案提示詞紀錄-11.md
+++ b/docs/專案提示詞紀錄/專案提示詞紀錄-11.md
@@ -957,13 +957,1078 @@ export const DataTableEditorPage: React.FC = () => {
 
 請問你需要哪一種方案呢？
 
-## ChatGPT 提問 
-## ChatGPT 回答 
-## ChatGPT 提問 
-## ChatGPT 回答 
-## ChatGPT 提問 
-## ChatGPT 回答 
-## ChatGPT 提問 
-## ChatGPT 回答 
-## ChatGPT 提問 
-## ChatGPT 回答 
+## Gemini 提問 資料表多重上傳
+關於"從後端 API 獲取資料表格"、"使用者上傳資料表格檔案"、"使用者建立空白資料表格"三種模式已經完成
+
+❓接下來想處理的問題：
+前面提到的"上傳"，是指單一個檔案上傳，會進入表格編輯頁面。
+
+現在要討論的是「多個檔案一起上傳」，此時我希望直接進行檔案解析和上傳到後端的流程，前端部分則跳轉到資料表格列表頁面(`DataTablesPage`)，於此頁面的右側邊欄(`rightPanelTitle`, `rightPanelContent`)顯示各檔案上傳狀態。
+- 右側邊欄要顯示已上傳檔案名稱與其上傳狀態，包含「上傳中」、「上傳成功」、「上傳失敗」等。
+- 每當有檔案上傳成功，資料表格列表刷新，增加該表格
+
+相關檔案：
+```tsx
+// src/components/DataTablesPage/UploadDataTableDialog.tsx
+import { useState } from "react";
+import {
+  Dialog,
+  DialogTitle,
+  DialogContent,
+  DialogActions,
+  Button,
+  RadioGroup,
+  Radio,
+  FormControlLabel,
+  Typography,
+  Box,
+  LinearProgress,
+  IconButton,
+} from "@mui/material";
+import CloudUploadIcon from "@mui/icons-material/CloudUpload";
+import CloseIcon from "@mui/icons-material/Close";
+import { useNavigate } from "react-router-dom";
+import type { UploadTableNavigateState } from "src/types";
+
+interface Props {
+  open: boolean;
+  onClose: () => void;
+}
+
+export const UploadDataTableDialog = ({ open, onClose }: Props) => {
+  const [uploadMode, setUploadMode] = useState<"mode1" | "mode2">("mode1");
+  const [selectedFiles, setSelectedFiles] = useState<File[]>([]);
+  const [uploading, setUploading] = useState(false);
+  const [isDragOver, setIsDragOver] = useState(false);
+  const navigate = useNavigate(); // 使用 Hook
+
+  const handleCancel = () => {
+    if (!uploading) {
+      setSelectedFiles([]);
+      onClose();
+    }
+  };
+
+  const fileTypeFilter = (file: File) =>
+    uploadMode === "mode1"
+      ? file.type === "text/csv" || file.type === "application/json"
+      : file.type === "application/json";
+
+  const fileNameRepeatFilter = (file: File) => {
+    const existingFileNames = selectedFiles.map((f) => f.name);
+    return !existingFileNames.includes(file.name);
+  };
+
+  const preprocessFiles = (files: FileList) => {
+    const fileArray = Array.from(files);
+    return fileArray.filter(fileTypeFilter).filter(fileNameRepeatFilter);
+  };
+
+  const handleFileChange = (event: React.ChangeEvent<HTMLInputElement>) => {
+    if (event.target.files) {
+      setSelectedFiles([
+        ...selectedFiles,
+        ...preprocessFiles(event.target.files),
+      ]);
+    }
+  };
+
+  const handleUpload = () => {
+    setUploading(true);
+    console.log(`正在以模式 ${uploadMode} 上傳以下檔案:`, selectedFiles);
+
+    setTimeout(() => {
+      setUploading(false);
+      onClose();
+      if (selectedFiles.length === 1) {
+        console.log("單一檔案上傳，導航至上傳資料表格頁面...");
+        // 使用 navigate 傳遞 state
+        const state: UploadTableNavigateState = {
+          editorMode: "upload",
+          file: selectedFiles[0],
+        };
+        navigate("/data-tables/edit", { state });
+      } else {
+        console.log("多個檔案上傳，返回資料表格列表頁...");
+        // TODO : 多檔案上傳後的處理邏輯
+        setSelectedFiles([]);
+      }
+    }, 2000);
+  };
+
+  // 拖曳事件處理器
+  const handleDragOver = (event: React.DragEvent<HTMLDivElement>) => {
+    event.preventDefault();
+    setIsDragOver(true);
+  };
+
+  const handleDragLeave = (event: React.DragEvent<HTMLDivElement>) => {
+    event.preventDefault();
+    setIsDragOver(false);
+  };
+
+  const handleDrop = (event: React.DragEvent<HTMLDivElement>) => {
+    event.preventDefault();
+    setIsDragOver(false);
+    if (event.dataTransfer?.files) {
+      setSelectedFiles([
+        ...selectedFiles,
+        ...preprocessFiles(event.dataTransfer.files),
+      ]);
+    }
+  };
+
+  // 處理移除檔案
+  const handleRemoveFile = (fileName: string) => {
+    setSelectedFiles(selectedFiles.filter((file) => file.name !== fileName));
+  };
+
+  return (
+    <Dialog open={open} onClose={handleCancel} maxWidth="sm" fullWidth>
+      <DialogTitle>上傳資料表格</DialogTitle>{" "}
+      <IconButton
+        aria-label="close"
+        onClick={handleCancel}
+        sx={(theme) => ({
+          position: "absolute",
+          right: 8,
+          top: 8,
+          color: theme.palette.grey[500],
+        })}
+      >
+        <CloseIcon />
+      </IconButton>
+      <DialogContent dividers>
+        <Typography variant="subtitle1" gutterBottom>
+          上傳模式
+        </Typography>
+        <RadioGroup
+          row
+          value={uploadMode}
+          onChange={(e) => setUploadMode(e.target.value as "mode1" | "mode2")}
+        >
+          <FormControlLabel
+            value="mode1"
+            control={<Radio />}
+            label="模式一：僅上傳資料內容"
+          />
+          <FormControlLabel
+            value="mode2"
+            control={<Radio />}
+            label="模式二：包含資訊與資料"
+          />
+        </RadioGroup>
+
+        <Typography variant="subtitle1" sx={{ mt: 2 }} gutterBottom>
+          上傳檔案
+        </Typography>
+        <Box
+          onDragOver={handleDragOver}
+          onDragLeave={handleDragLeave}
+          onDrop={handleDrop}
+          sx={{
+            border: "2px dashed #ccc",
+            borderColor: isDragOver ? "primary.main" : "#ccc",
+            borderRadius: 2,
+            p: 4,
+            textAlign: "center",
+            cursor: "pointer",
+            bgcolor: isDragOver ? "action.hover" : "#f9f9f9",
+            transition: "all 0.3s ease-in-out",
+          }}
+          onClick={() => document.getElementById("file-upload-input")?.click()}
+        >
+          <CloudUploadIcon color="primary" sx={{ fontSize: 40 }} />
+          <Typography>拖曳檔案到此處，或點擊上傳</Typography>
+          <input
+            id="file-upload-input"
+            type="file"
+            multiple
+            hidden
+            onChange={handleFileChange}
+            accept={
+              uploadMode === "mode1"
+                ? "text/csv, application/json"
+                : "application/json"
+            }
+          />
+        </Box>
+        {selectedFiles.length > 0 && (
+          <Box sx={{ mt: 2 }}>
+            <Typography variant="body2" sx={{ mb: 1 }}>
+              已選擇檔案:
+            </Typography>
+            <ul style={{ listStyleType: "none", padding: 0 }}>
+              {selectedFiles.map((file) => (
+                <li
+                  key={file.name}
+                  style={{
+                    display: "flex",
+                    alignItems: "center",
+                    justifyContent: "space-between",
+                    padding: "4px 8px",
+                    border: "1px solid #eee",
+                    borderRadius: "4px",
+                    marginBottom: "4px",
+                  }}
+                >
+                  <Typography variant="body2">{file.name}</Typography>
+                  <IconButton
+                    size="small"
+                    onClick={() => handleRemoveFile(file.name)}
+                    sx={{ p: 0.5 }}
+                  >
+                    <CloseIcon fontSize="small" />
+                  </IconButton>
+                </li>
+              ))}
+            </ul>
+          </Box>
+        )}
+        {uploading && <LinearProgress sx={{ mt: 2 }} />}
+      </DialogContent>
+      <DialogActions>
+        <Button onClick={handleCancel} disabled={uploading}>
+          取消
+        </Button>
+        <Button
+          onClick={handleUpload}
+          variant="contained"
+          disabled={selectedFiles.length === 0 || uploading}
+        >
+          確認
+        </Button>
+      </DialogActions>
+    </Dialog>
+  );
+};
+```
+
+```tsx
+// src/pages/DataTablesPage.tsx
+import { useEffect, useState } from "react";
+import { useNavigate } from "react-router-dom";
+import {
+  Box,
+  Typography,
+  TextField,
+  Button,
+  Grid,
+  ToggleButtonGroup,
+  ToggleButton,
+} from "@mui/material";
+import FormatListBulletedIcon from "@mui/icons-material/FormatListBulleted";
+import AddIcon from "@mui/icons-material/Add";
+import UploadIcon from "@mui/icons-material/Upload";
+import GridViewIcon from "@mui/icons-material/GridView";
+import { PageWrapper } from "../components/layout/PageWrapper";
+import { DataTableList } from "../components/DataTablesPage/DataTableList";
+import { UploadDataTableDialog } from "../components/DataTablesPage/UploadDataTableDialog";
+import type { DataTableInfo } from "shared/types/dataTable";
+import type { CreateTableNavigateState, PageConfig } from "../types";
+
+export const DataTablesPage = () => {
+  const [searchText, setSearchText] = useState("");
+  const [uploadDialogOpen, setUploadDialogOpen] = useState(false);
+  const [viewMode, setViewMode] = useState<"card" | "list">("card");
+  const [tableInfos, setTableInfos] = useState<DataTableInfo[]>([]); // 真正從後端來的資料
+  const navigate = useNavigate();
+  console.log("DataTablesPage");
+
+  useEffect(() => {
+    // 載入後端資料表資訊
+    refreshTableInfos();
+  }, []);
+
+  const refreshTableInfos = () => {
+    window.api.getAllTableInfos().then((tables) => {
+      setTableInfos(tables);
+    });
+  };
+
+  // 根據搜尋關鍵字過濾資料
+  const filteredDataTables = tableInfos.filter((table) =>
+    table.name.toLowerCase().includes(searchText.toLowerCase())
+  );
+
+  const handleViewModeChange = (
+    _event: React.MouseEvent<HTMLElement>,
+    newViewMode: "card" | "list"
+  ) => {
+    // 只有當新模式不為 null 時才更新狀態
+    if (newViewMode !== null) {
+      setViewMode(newViewMode);
+    }
+  };
+
+  const handleNewTableClick = () => {
+    const state: CreateTableNavigateState = { editorMode: "create" };
+    navigate("/data-tables/edit", { state });
+  };
+
+  // 頁面配置
+  const pageConfig: Omit<PageConfig, "tocItems"> = {
+    breadcrumbItems: [{ label: "資料表格管理", path: "/data-tables" }],
+    content: (
+      <Box sx={{ p: 3 }}>
+        <Grid container alignItems="center" spacing={2} sx={{ mb: 3 }}>
+          <Grid
+            size={{ xs: 12, sm: 6 }}
+            container
+            alignItems="center"
+            spacing={2}
+          >
+            {/* 標題與模式切換按鈕 */}
+            <Grid>
+              <Typography variant="h4" sx={{ fontWeight: "bold" }}>
+                資料表格管理
+              </Typography>
+            </Grid>
+            <Grid>
+              <ToggleButtonGroup
+                value={viewMode}
+                exclusive
+                onChange={handleViewModeChange}
+                aria-label="view mode"
+                size="small"
+              >
+                <ToggleButton value="card" aria-label="card view">
+                  <GridViewIcon />
+                </ToggleButton>
+                <ToggleButton value="list" aria-label="list view">
+                  <FormatListBulletedIcon />
+                </ToggleButton>
+              </ToggleButtonGroup>
+            </Grid>
+          </Grid>
+          <Grid
+            size={{ xs: 12, sm: 6 }}
+            container
+            justifyContent="flex-end"
+            spacing={1}
+          >
+            {/* 搜尋框 */}
+            <Grid>
+              <TextField
+                label="搜尋表格"
+                variant="outlined"
+                size="small"
+                value={searchText}
+                onChange={(e) => setSearchText(e.target.value)}
+              />
+            </Grid>
+            {/* 新增表格按鈕 */}
+            <Grid>
+              <Button
+                variant="contained"
+                startIcon={<AddIcon />}
+                onClick={() => handleNewTableClick()}
+              >
+                新增資料表格
+              </Button>
+            </Grid>
+            {/* 上傳按鈕 */}
+            <Grid>
+              <Button
+                variant="contained"
+                startIcon={<UploadIcon />}
+                onClick={() => setUploadDialogOpen(true)}
+              >
+                上傳資料表格
+              </Button>
+            </Grid>
+          </Grid>
+        </Grid>
+
+        {/* 將 viewMode 作為 props 傳遞給 DataTableList */}
+        <DataTableList
+          dataTables={filteredDataTables}
+          viewMode={viewMode}
+          refreshTableInfos={refreshTableInfos}
+        />
+
+        {/* 上傳資料表格對話框 */}
+        <UploadDataTableDialog
+          open={uploadDialogOpen}
+          onClose={() => setUploadDialogOpen(false)}
+        />
+      </Box>
+    ),
+  };
+
+  return <PageWrapper {...pageConfig} />;
+};
+```
+
+```tsx
+// src/hooks/useFileParser.ts
+import { useState, useEffect } from "react";
+import { parseDataFile } from "../utils";
+import type { DataTableHeaderSchema } from "shared/types/dataTable";
+
+interface UseFileParserReturn {
+  loading: boolean;
+  data: DataTableHeaderSchema | null;
+  error: string | null;
+}
+
+export const useFileParser = (
+  file: File | null | undefined
+): UseFileParserReturn => {
+  const [loading, setLoading] = useState(true);
+  const [data, setData] = useState<DataTableHeaderSchema | null>(null);
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    const processFile = async () => {
+      if (!file) {
+        setError("無檔案資料。請返回資料表格列表頁重新上傳。");
+        setLoading(false);
+        return;
+      }
+
+      try {
+        setLoading(true);
+        setError(null);
+        const parsedData = await parseDataFile(file);
+        setData(parsedData);
+      } catch (e: unknown) {
+        if (e instanceof Error) {
+          setError(e.message);
+        } else {
+          setError("解析檔案時發生未知錯誤");
+        }
+      } finally {
+        setLoading(false);
+      }
+    };
+
+    processFile();
+  }, [file]);
+
+  return { loading, data, error };
+};
+```
+
+```tsx
+// src/preload.d.ts
+...
+interface DataTableAPI {
+  uploadTable: (
+    tableInfo: { name: string; description?: string },
+    content: DataTableHeaderSchema
+  ) => Promise<DataTableInfo>;
+  getAllTableInfos: () => Promise<DataTableInfo[]>;
+  getTable: (id: TableId) => Promise<DataTableWithInfo>;
+  ...
+}
+
+interface ChartAPI {
+  ...
+}
+
+declare global {
+  interface Window {
+    api: DataTableAPI & ChartAPI;
+  }
+}
+```
+
+## Gemini 回答 資料表多重上傳
+好的，我已經理解您的需求。為了實現多檔案上傳並即時顯示狀態，我們需要引入一個狀態管理機制，將上傳狀態從對話框 (`UploadDataTableDialog`) 傳遞給資料表格列表頁面 (`DataTablesPage`)。
+
+由於您的專案已經使用了 Zustand，這將是完美的解決方案。我將為您新增一個 Zustand Store 來管理檔案的上傳狀態，並對您現有的元件進行重構。
+
+以下是重構的詳細步驟和程式碼：
+
+### 1\. 新增 `stores/uploadStore.ts`
+
+這個檔案將創建一個 Zustand Store，用於儲存所有正在上傳或已上傳完成的檔案及其狀態。
+
+```tsx
+// src/stores/uploadStore.ts
+import { create } from "zustand";
+import { devtools } from "zustand/middleware";
+import { parseDataFile } from "../utils";
+import { DataTableInfo } from "shared/types/dataTable";
+
+export interface FileUploadStatus {
+  id: string; // 使用檔案名稱作為唯一 ID
+  fileName: string;
+  status: "uploading" | "success" | "failed";
+  progress?: number;
+  error?: string;
+  info?: DataTableInfo;
+}
+
+interface UploadState {
+  uploads: FileUploadStatus[];
+  addUpload: (file: File) => void;
+  updateUploadStatus: (
+    fileName: string,
+    status: FileUploadStatus["status"],
+    info?: DataTableInfo,
+    error?: string
+  ) => void;
+  // 處理上傳檔案的非同步邏輯
+  startUploads: (files: File[]) => Promise<void>;
+  reset: () => void;
+}
+
+export const useUploadStore = create<UploadState>()(
+  devtools(
+    (set, get) => ({
+      uploads: [],
+
+      addUpload: (file: File) => {
+        set((state) => ({
+          uploads: [
+            ...state.uploads,
+            { id: file.name, fileName: file.name, status: "uploading" },
+          ],
+        }));
+      },
+
+      updateUploadStatus: (fileName, status, info, error) => {
+        set((state) => ({
+          uploads: state.uploads.map((upload) =>
+            upload.fileName === fileName
+              ? { ...upload, status, info, error }
+              : upload
+          ),
+        }));
+      },
+
+      startUploads: async (files: File[]) => {
+        const { updateUploadStatus, addUpload } = get();
+
+        // 遍歷所有檔案並開始上傳
+        for (const file of files) {
+          addUpload(file);
+          try {
+            // 模擬解析檔案
+            const parsedData = await parseDataFile(file);
+            // 呼叫後端 API
+            const tableInfo = { name: file.name.split(".")[0], description: "" };
+            const dataTableInfo = await window.api.uploadTable(
+              tableInfo,
+              parsedData
+            );
+            // 更新狀態為成功
+            updateUploadStatus(file.name, "success", dataTableInfo);
+          } catch (e: unknown) {
+            console.error(`上傳 ${file.name} 失敗:`, e);
+            const errorMsg = e instanceof Error ? e.message : "未知錯誤";
+            // 更新狀態為失敗
+            updateUploadStatus(file.name, "failed", undefined, errorMsg);
+          }
+        }
+      },
+      
+      reset: () => {
+        set({ uploads: [] });
+      },
+    }),
+    { name: "upload-store" } // 開發者工具名稱
+  )
+);
+```
+
+### 2\. 重構 `src/components/DataTablesPage/UploadDataTableDialog.tsx`
+
+這個對話框現在將使用 `useUploadStore` 來處理上傳邏輯，並在多個檔案時直接關閉對話框，將上傳過程交由 Zustand Store 處理。
+
+```tsx
+// src/components/DataTablesPage/UploadDataTableDialog.tsx
+import { useState } from "react";
+import {
+  Dialog,
+  DialogTitle,
+  DialogContent,
+  DialogActions,
+  Button,
+  RadioGroup,
+  Radio,
+  FormControlLabel,
+  Typography,
+  Box,
+  LinearProgress,
+  IconButton,
+} from "@mui/material";
+import CloudUploadIcon from "@mui/icons-material/CloudUpload";
+import CloseIcon from "@mui/icons-material/Close";
+import { useNavigate } from "react-router-dom";
+import type { UploadTableNavigateState } from "src/types";
+import { useUploadStore } from "src/stores/uploadStore";
+
+interface Props {
+  open: boolean;
+  onClose: () => void;
+}
+
+export const UploadDataTableDialog = ({ open, onClose }: Props) => {
+  const [uploadMode, setUploadMode] = useState<"mode1" | "mode2">("mode1");
+  const [selectedFiles, setSelectedFiles] = useState<File[]>([]);
+  const [isDragOver, setIsDragOver] = useState(false);
+  const navigate = useNavigate();
+  const { startUploads } = useUploadStore();
+
+  const handleCancel = () => {
+    // 這裡我們不再需要檢查 uploading 狀態，因為上傳是非同步在 Store 裡進行的
+    setSelectedFiles([]);
+    onClose();
+  };
+
+  const fileTypeFilter = (file: File) =>
+    uploadMode === "mode1"
+      ? file.type === "text/csv" || file.type === "application/json"
+      : file.type === "application/json";
+
+  const fileNameRepeatFilter = (file: File) => {
+    const existingFileNames = selectedFiles.map((f) => f.name);
+    return !existingFileNames.includes(file.name);
+  };
+
+  const preprocessFiles = (files: FileList) => {
+    const fileArray = Array.from(files);
+    return fileArray.filter(fileTypeFilter).filter(fileNameRepeatFilter);
+  };
+
+  const handleFileChange = (event: React.ChangeEvent<HTMLInputElement>) => {
+    if (event.target.files) {
+      setSelectedFiles([
+        ...selectedFiles,
+        ...preprocessFiles(event.target.files),
+      ]);
+    }
+  };
+
+  const handleUpload = () => {
+    if (selectedFiles.length === 0) return;
+
+    if (selectedFiles.length === 1) {
+      console.log("單一檔案上傳，導航至上傳資料表格頁面...");
+      onClose();
+      const state: UploadTableNavigateState = {
+        editorMode: "upload",
+        file: selectedFiles[0],
+      };
+      navigate("/data-tables/edit", { state });
+    } else {
+      console.log("多個檔案上傳，開始非同步上傳流程並返回列表頁...");
+      // 呼叫 Zustand Store 的 action 來開始上傳
+      startUploads(selectedFiles);
+      // 關閉對話框
+      onClose();
+      setSelectedFiles([]);
+    }
+  };
+
+  // ... (其他拖曳事件處理器不變)
+
+  const handleDragOver = (event: React.DragEvent<HTMLDivElement>) => {
+    event.preventDefault();
+    setIsDragOver(true);
+  };
+
+  const handleDragLeave = (event: React.DragEvent<HTMLDivElement>) => {
+    event.preventDefault();
+    setIsDragOver(false);
+  };
+
+  const handleDrop = (event: React.DragEvent<HTMLDivElement>) => {
+    event.preventDefault();
+    setIsDragOver(false);
+    if (event.dataTransfer?.files) {
+      setSelectedFiles([
+        ...selectedFiles,
+        ...preprocessFiles(event.dataTransfer.files),
+      ]);
+    }
+  };
+
+  const handleRemoveFile = (fileName: string) => {
+    setSelectedFiles(selectedFiles.filter((file) => file.name !== fileName));
+  };
+  
+  // 判斷是否有檔案正在上傳，這裡可以從 store 讀取狀態
+  const uploading = useUploadStore((state) => state.uploads.some(u => u.status === 'uploading'));
+
+
+  return (
+    <Dialog open={open} onClose={handleCancel} maxWidth="sm" fullWidth>
+      <DialogTitle>上傳資料表格</DialogTitle>
+      <IconButton
+        aria-label="close"
+        onClick={handleCancel}
+        sx={(theme) => ({
+          position: "absolute",
+          right: 8,
+          top: 8,
+          color: theme.palette.grey[500],
+        })}
+      >
+        <CloseIcon />
+      </IconButton>
+      <DialogContent dividers>
+        <Typography variant="subtitle1" gutterBottom>
+          上傳模式
+        </Typography>
+        <RadioGroup
+          row
+          value={uploadMode}
+          onChange={(e) => setUploadMode(e.target.value as "mode1" | "mode2")}
+        >
+          <FormControlLabel
+            value="mode1"
+            control={<Radio />}
+            label="模式一：僅上傳資料內容"
+          />
+          <FormControlLabel
+            value="mode2"
+            control={<Radio />}
+            label="模式二：包含資訊與資料"
+          />
+        </RadioGroup>
+
+        <Typography variant="subtitle1" sx={{ mt: 2 }} gutterBottom>
+          上傳檔案
+        </Typography>
+        <Box
+          onDragOver={handleDragOver}
+          onDragLeave={handleDragLeave}
+          onDrop={handleDrop}
+          sx={{
+            border: "2px dashed #ccc",
+            borderColor: isDragOver ? "primary.main" : "#ccc",
+            borderRadius: 2,
+            p: 4,
+            textAlign: "center",
+            cursor: "pointer",
+            bgcolor: isDragOver ? "action.hover" : "#f9f9f9",
+            transition: "all 0.3s ease-in-out",
+          }}
+          onClick={() => document.getElementById("file-upload-input")?.click()}
+        >
+          <CloudUploadIcon color="primary" sx={{ fontSize: 40 }} />
+          <Typography>拖曳檔案到此處，或點擊上傳</Typography>
+          <input
+            id="file-upload-input"
+            type="file"
+            multiple
+            hidden
+            onChange={handleFileChange}
+            accept={
+              uploadMode === "mode1"
+                ? "text/csv, application/json"
+                : "application/json"
+            }
+          />
+        </Box>
+        {selectedFiles.length > 0 && (
+          <Box sx={{ mt: 2 }}>
+            <Typography variant="body2" sx={{ mb: 1 }}>
+              已選擇檔案:
+            </Typography>
+            <ul style={{ listStyleType: "none", padding: 0 }}>
+              {selectedFiles.map((file) => (
+                <li
+                  key={file.name}
+                  style={{
+                    display: "flex",
+                    alignItems: "center",
+                    justifyContent: "space-between",
+                    padding: "4px 8px",
+                    border: "1px solid #eee",
+                    borderRadius: "4px",
+                    marginBottom: "4px",
+                  }}
+                >
+                  <Typography variant="body2">{file.name}</Typography>
+                  <IconButton
+                    size="small"
+                    onClick={() => handleRemoveFile(file.name)}
+                    sx={{ p: 0.5 }}
+                  >
+                    <CloseIcon fontSize="small" />
+                  </IconButton>
+                </li>
+              ))}
+            </ul>
+          </Box>
+        )}
+      </DialogContent>
+      <DialogActions>
+        <Button onClick={handleCancel} disabled={uploading}>
+          取消
+        </Button>
+        <Button
+          onClick={handleUpload}
+          variant="contained"
+          disabled={selectedFiles.length === 0 || uploading}
+        >
+          確認
+        </Button>
+      </DialogActions>
+    </Dialog>
+  );
+};
+```
+
+### 3\. 重構 `src/pages/DataTablesPage.tsx`
+
+在這個頁面中，我們將使用 `useUploadStore` 的狀態來渲染側邊欄，並在有檔案上傳成功時觸發資料列表刷新。
+
+```tsx
+// src/pages/DataTablesPage.tsx
+import { useEffect, useState } from "react";
+import { useNavigate } from "react-router-dom";
+import {
+  Box,
+  Typography,
+  TextField,
+  Button,
+  Grid,
+  ToggleButtonGroup,
+  ToggleButton,
+} from "@mui/material";
+import FormatListBulletedIcon from "@mui/icons-material/FormatListBulleted";
+import AddIcon from "@mui/icons-material/Add";
+import UploadIcon from "@mui/icons-material/Upload";
+import GridViewIcon from "@mui/icons-material/GridView";
+import { PageWrapper } from "../components/layout/PageWrapper";
+import { DataTableList } from "../components/DataTablesPage/DataTableList";
+import { UploadDataTableDialog } from "../components/DataTablesPage/UploadDataTableDialog";
+import { useUploadStore } from "../stores/uploadStore";
+import type { DataTableInfo } from "shared/types/dataTable";
+import type { CreateTableNavigateState, PageConfig } from "../types";
+import { UploadStatusPanel } from "../components/DataTablesPage/UploadStatusPanel"; // 新增元件
+
+export const DataTablesPage = () => {
+  const [searchText, setSearchText] = useState("");
+  const [uploadDialogOpen, setUploadDialogOpen] = useState(false);
+  const [viewMode, setViewMode] = useState<"card" | "list">("card");
+  const [tableInfos, setTableInfos] = useState<DataTableInfo[]>([]);
+  const navigate = useNavigate();
+
+  // 從 Zustand Store 獲取上傳狀態
+  const uploads = useUploadStore((state) => state.uploads);
+  const resetUploads = useUploadStore((state) => state.reset);
+  
+  // 監聽 uploads 狀態的變化，並在有成功上傳時刷新列表
+  useEffect(() => {
+    if (uploads.some(u => u.status === 'success')) {
+      refreshTableInfos();
+    }
+  }, [uploads]);
+
+  useEffect(() => {
+    refreshTableInfos();
+    // 頁面初次載入時清空上傳狀態，避免上次的紀錄影響本次
+    return () => {
+      resetUploads();
+    };
+  }, []);
+
+  const refreshTableInfos = () => {
+    window.api.getAllTableInfos().then((tables) => {
+      setTableInfos(tables);
+    });
+  };
+
+  const filteredDataTables = tableInfos.filter((table) =>
+    table.name.toLowerCase().includes(searchText.toLowerCase())
+  );
+
+  const handleViewModeChange = (
+    _event: React.MouseEvent<HTMLElement>,
+    newViewMode: "card" | "list"
+  ) => {
+    if (newViewMode !== null) {
+      setViewMode(newViewMode);
+    }
+  };
+
+  const handleNewTableClick = () => {
+    const state: CreateTableNavigateState = { editorMode: "create" };
+    navigate("/data-tables/edit", { state });
+  };
+
+  const pageConfig: Omit<PageConfig, "tocItems"> = {
+    breadcrumbItems: [{ label: "資料表格管理", path: "/data-tables" }],
+    content: (
+      <Box sx={{ p: 3 }}>
+        <Grid container alignItems="center" spacing={2} sx={{ mb: 3 }}>
+          <Grid
+            item
+            xs={12}
+            sm={6}
+            container
+            alignItems="center"
+            spacing={2}
+          >
+            <Grid item>
+              <Typography variant="h4" sx={{ fontWeight: "bold" }}>
+                資料表格管理
+              </Typography>
+            </Grid>
+            <Grid item>
+              <ToggleButtonGroup
+                value={viewMode}
+                exclusive
+                onChange={handleViewModeChange}
+                aria-label="view mode"
+                size="small"
+              >
+                <ToggleButton value="card" aria-label="card view">
+                  <GridViewIcon />
+                </ToggleButton>
+                <ToggleButton value="list" aria-label="list view">
+                  <FormatListBulletedIcon />
+                </ToggleButton>
+              </ToggleButtonGroup>
+            </Grid>
+          </Grid>
+          <Grid
+            item
+            xs={12}
+            sm={6}
+            container
+            justifyContent="flex-end"
+            spacing={1}
+          >
+            <Grid item>
+              <TextField
+                label="搜尋表格"
+                variant="outlined"
+                size="small"
+                value={searchText}
+                onChange={(e) => setSearchText(e.target.value)}
+              />
+            </Grid>
+            <Grid item>
+              <Button
+                variant="contained"
+                startIcon={<AddIcon />}
+                onClick={() => handleNewTableClick()}
+              >
+                新增資料表格
+              </Button>
+            </Grid>
+            <Grid item>
+              <Button
+                variant="contained"
+                startIcon={<UploadIcon />}
+                onClick={() => setUploadDialogOpen(true)}
+              >
+                上傳資料表格
+              </Button>
+            </Grid>
+          </Grid>
+        </Grid>
+        <DataTableList
+          dataTables={filteredDataTables}
+          viewMode={viewMode}
+          refreshTableInfos={refreshTableInfos}
+        />
+        <UploadDataTableDialog
+          open={uploadDialogOpen}
+          onClose={() => setUploadDialogOpen(false)}
+        />
+      </Box>
+    ),
+    rightPanelContent: <UploadStatusPanel />, // 這裡使用新元件
+    rightPanelTitle: uploads.length > 0 ? "上傳狀態" : "編輯控制面板",
+  };
+
+  return <PageWrapper {...pageConfig} />;
+};
+```
+
+### 4\. 新增 `src/components/DataTablesPage/UploadStatusPanel.tsx`
+
+這個新元件將專門負責從 Zustand Store 讀取上傳狀態，並渲染到右側邊欄。
+
+```tsx
+// src/components/DataTablesPage/UploadStatusPanel.tsx
+import React from "react";
+import { Box, Typography, List, ListItem, ListItemText, LinearProgress, Paper } from "@mui/material";
+import CheckCircleIcon from "@mui/icons-material/CheckCircle";
+import ErrorIcon from "@mui/icons-material/Error";
+import CloudUploadIcon from "@mui/icons-material/CloudUpload";
+import { useUploadStore, FileUploadStatus } from "../../stores/uploadStore";
+
+const getIcon = (status: FileUploadStatus['status']) => {
+  switch (status) {
+    case 'success':
+      return <CheckCircleIcon color="success" sx={{ mr: 1 }} />;
+    case 'failed':
+      return <ErrorIcon color="error" sx={{ mr: 1 }} />;
+    case 'uploading':
+    default:
+      return <CloudUploadIcon color="primary" sx={{ mr: 1 }} />;
+  }
+};
+
+export const UploadStatusPanel: React.FC = () => {
+  const uploads = useUploadStore((state) => state.uploads);
+
+  if (uploads.length === 0) {
+    return (
+      <Box sx={{ p: 2 }}>
+        <Typography variant="h6">編輯控制面板</Typography>
+        <Typography variant="body2" sx={{ mt: 1 }}>
+          這裡可以添加欄位類型、篩選、排序等控制項。
+        </Typography>
+      </Box>
+    );
+  }
+
+  return (
+    <Box sx={{ p: 2 }}>
+      <Typography variant="h6">上傳狀態</Typography>
+      <List dense sx={{ mt: 1 }}>
+        {uploads.map((upload) => (
+          <Paper key={upload.id} elevation={1} sx={{ mb: 1, p: 1 }}>
+            <ListItem disablePadding>
+              {getIcon(upload.status)}
+              <ListItemText
+                primary={
+                  <Typography variant="body2" sx={{ fontWeight: 'bold' }}>
+                    {upload.fileName}
+                  </Typography>
+                }
+                secondary={
+                  <Typography variant="body2" color="text.secondary">
+                    {upload.status === 'uploading'
+                      ? "上傳中..."
+                      : upload.status === 'success'
+                      ? `上傳成功`
+                      : `上傳失敗: ${upload.error}`}
+                  </Typography>
+                }
+              />
+            </ListItem>
+            {upload.status === 'uploading' && <LinearProgress />}
+          </Paper>
+        ))}
+      </List>
+    </Box>
+  );
+};
+```
+
+### 5\. `src/utils.ts` 和其他相關檔案的調整
+
+為了讓 `useUploadStore` 能夠直接調用上傳邏輯，我們需要確保 `parseDataFile` 和 `window.api.uploadTable` 是可用的。您的原始碼已經具備這些功能，所以這部分無需額外變動。
+
+### 總結
+
+這個方案利用了 Zustand 的**全域狀態管理**能力，完美地將上傳邏輯與 UI 渲染分離，解決了父子元件間的狀態傳遞問題。
+
+  * 當使用者點擊「確認」上傳多個檔案時，`UploadDataTableDialog` 會呼叫 `useUploadStore` 中的 `startUploads` 方法。
+  * `startUploads` 會非同步地處理每個檔案的解析和上傳，並即時更新 Store 中的 `uploads` 陣列。
+  * `DataTablesPage` 中的 `UploadStatusPanel` 元件會**自動訂閱** `uploads` 陣列的變化，當狀態更新時，UI 會自動重新渲染，顯示最新的上傳進度。
+  * 同時，`DataTablesPage` 頁面也會監聽 `uploads` 的狀態，並在偵測到有成功上傳時，自動調用 `refreshTableInfos` 刷新列表，確保使用者看到最新的資料。
+
+這個設計模式不僅實現了您的需求，也使程式碼更加健壯、可維護。

--- a/docs/專案提示詞紀錄/專案提示詞紀錄-12.md
+++ b/docs/專案提示詞紀錄/專案提示詞紀錄-12.md
@@ -1,0 +1,240 @@
+## Gemini 提問 資料表多重上傳-狀態條修整
+🔧 目前狀態：
+我將你提供的代碼加到我的專案中，「多個資料表同時上傳」功能實現的很好，右側邊欄的狀態條也很棒。
+
+❓接下來想處理的問題：
+- `FileUploadStatus` 不應該用檔名作為 ID，如果使用者上傳同名檔案，會發生覆蓋，應該加入時間戳或者隨機數
+- 狀態條永久停留，我希望成功的狀態條只停留 10 秒，失敗的狀態條停留 30 秒。
+- 給已經上傳結束的狀態條(無論成功或失敗)加上叉叉按鈕，可以直接刪除該狀態條。
+
+## Gemini 回答 資料表多重上傳-狀態條修整
+好的，這些都是非常合理的優化。我們將針對這三個問題，對 `src/stores/uploadStore.ts` 以及相關的 UI 元件進行修改。
+
+-----
+
+### 1\. 解決同名檔案覆蓋問題
+
+您的觀察非常正確，單純使用檔名作為 ID 在處理同名檔案時會出問題。我們可以為每個上傳任務生成一個唯一的 ID 來解決這個問題。使用 `Date.now()` 和一個隨機數的組合是一個簡單且有效的方法。
+
+#### `src/stores/uploadStore.ts` 修改
+
+```typescript
+// src/stores/uploadStore.ts
+import { create } from "zustand";
+import { devtools } from "zustand/middleware";
+import { parseDataFile } from "../utils";
+import { DataTableInfo } from "shared/types/dataTable";
+
+export interface FileUploadStatus {
+  id: string; // 使用隨機數作為唯一 ID
+  fileName: string;
+  status: "uploading" | "success" | "failed";
+  progress?: number;
+  error?: string;
+  info?: DataTableInfo;
+  timeoutId?: ReturnType<typeof setTimeout>; // 用於儲存定時器 ID
+}
+
+interface UploadState {
+  uploads: FileUploadStatus[];
+  addUpload: (file: File) => string; // 回傳新建立的 ID
+  updateUploadStatus: (
+    id: string,
+    status: FileUploadStatus["status"],
+    info?: DataTableInfo,
+    error?: string
+  ) => void;
+  // 處理上傳檔案的非同步邏輯
+  startUploads: (files: File[]) => Promise<void>;
+  reset: () => void;
+  removeUpload: (id: string) => void; // 新增移除方法
+}
+
+export const useUploadStore = create<UploadState>()(
+  devtools(
+    (set, get) => ({
+      uploads: [],
+
+      addUpload: (file: File) => {
+        const newId = `${Date.now()}-${Math.random().toString(36).substr(2, 9)}`;
+        set((state) => ({
+          uploads: [
+            ...state.uploads,
+            { id: newId, fileName: file.name, status: "uploading" },
+          ],
+        }));
+        return newId;
+      },
+
+      updateUploadStatus: (id, status, info, error) => {
+        set((state) => ({
+          uploads: state.uploads.map((upload) =>
+            upload.id === id ? { ...upload, status, info, error } : upload
+          ),
+        }));
+      },
+
+      removeUpload: (id) => {
+        set((state) => ({
+          uploads: state.uploads.filter((upload) => upload.id !== id),
+        }));
+      },
+
+      startUploads: async (files: File[]) => {
+        const { updateUploadStatus, addUpload, removeUpload } = get();
+
+        for (const file of files) {
+          const newId = addUpload(file);
+          try {
+            const parsedData = await parseDataFile(file);
+            const tableInfo = { name: file.name.split(".")[0], description: "" };
+            const dataTableInfo = await window.api.uploadTable(
+              tableInfo,
+              parsedData
+            );
+            updateUploadStatus(newId, "success", dataTableInfo);
+            // 成功後設定定時器
+            setTimeout(() => {
+              removeUpload(newId);
+            }, 10000); // 10 秒後自動移除
+          } catch (e: unknown) {
+            console.error(`上傳 ${file.name} 失敗:`, e);
+            const errorMsg = e instanceof Error ? e.message : "未知錯誤";
+            updateUploadStatus(newId, "failed", undefined, errorMsg);
+            // 失敗後設定定時器
+            setTimeout(() => {
+              removeUpload(newId);
+            }, 30000); // 30 秒後自動移除
+          }
+        }
+      },
+      
+      reset: () => {
+        set({ uploads: [] });
+      },
+    }),
+    { name: "upload-store" }
+  )
+);
+```
+
+### 2\. 狀態條自動移除與手動刪除按鈕
+
+為了實現自動移除，我們可以在 `startUploads` 方法中，當檔案上傳成功或失敗後，使用 `setTimeout` 來自動呼叫 `removeUpload` 方法。同時，我們需要給已完成的狀態條加上手動移除的按鈕。
+
+#### `src/components/DataTablesPage/UploadStatusPanel.tsx` 修改
+
+```tsx
+// src/components/DataTablesPage/UploadStatusPanel.tsx
+import React from "react";
+import {
+  Box,
+  Typography,
+  List,
+  ListItem,
+  ListItemText,
+  LinearProgress,
+  Paper,
+  IconButton,
+} from "@mui/material";
+import CheckCircleIcon from "@mui/icons-material/CheckCircle";
+import ErrorIcon from "@mui/icons-material/Error";
+import CloudUploadIcon from "@mui/icons-material/CloudUpload";
+import CloseIcon from "@mui/icons-material/Close"; // 引入叉叉圖示
+import { useUploadStore, FileUploadStatus } from "../../stores/uploadStore";
+
+const getIcon = (status: FileUploadStatus['status']) => {
+  switch (status) {
+    case 'success':
+      return <CheckCircleIcon color="success" sx={{ mr: 1 }} />;
+    case 'failed':
+      return <ErrorIcon color="error" sx={{ mr: 1 }} />;
+    case 'uploading':
+    default:
+      return <CloudUploadIcon color="primary" sx={{ mr: 1 }} />;
+  }
+};
+
+export const UploadStatusPanel: React.FC = () => {
+  const uploads = useUploadStore((state) => state.uploads);
+  const removeUpload = useUploadStore((state) => state.removeUpload); // 取得移除方法
+
+  if (uploads.length === 0) {
+    return (
+      <Box sx={{ p: 2 }}>
+        <Typography variant="h6">編輯控制面板</Typography>
+        <Typography variant="body2" sx={{ mt: 1 }}>
+          這裡可以添加欄位類型、篩選、排序等控制項。
+        </Typography>
+      </Box>
+    );
+  }
+
+  return (
+    <Box sx={{ p: 2 }}>
+      <Typography variant="h6">上傳狀態</Typography>
+      <List dense sx={{ mt: 1 }}>
+        {uploads.map((upload) => (
+          <Paper key={upload.id} elevation={1} sx={{ mb: 1, p: 1 }}>
+            <ListItem
+              disablePadding
+              secondaryAction={
+                (upload.status === "success" || upload.status === "failed") && (
+                  <IconButton
+                    edge="end"
+                    aria-label="delete"
+                    onClick={() => removeUpload(upload.id)}
+                    size="small"
+                  >
+                    <CloseIcon />
+                  </IconButton>
+                )
+              }
+            >
+              {getIcon(upload.status)}
+              <ListItemText
+                primary={
+                  <Typography variant="body2" sx={{ fontWeight: "bold" }}>
+                    {upload.fileName}
+                  </Typography>
+                }
+                secondary={
+                  <Typography variant="body2" color="text.secondary">
+                    {upload.status === "uploading"
+                      ? "上傳中..."
+                      : upload.status === "success"
+                      ? `上傳成功`
+                      : `上傳失敗: ${upload.error}`}
+                  </Typography>
+                }
+              />
+            </ListItem>
+            {upload.status === "uploading" && <LinearProgress />}
+          </Paper>
+        ))}
+      </List>
+    </Box>
+  );
+};
+```
+
+-----
+
+### 總結
+
+1.  **唯一 ID**：我們在 `useUploadStore` 的 `addUpload` 方法中，為每個上傳任務生成了一個唯一的 ID，這徹底解決了同名檔案的覆蓋問題。
+2.  **自動移除**：在 `startUploads` 方法中，我們為成功和失敗的任務分別設定了 10 秒和 30 秒的定時器，時間一到，`setTimeout` 會觸發 `removeUpload`，自動從列表中移除該任務。
+3.  **手動移除**：在 `UploadStatusPanel` 元件中，我們利用 MUI 的 `ListItem` 的 `secondaryAction` 屬性，為已完成（成功或失敗）的狀態條添加了一個叉叉按鈕，使用者可以隨時手動移除它。
+
+這三個優化使得多檔案上傳功能更加健壯和人性化，提供了更好的使用者體驗。
+
+## Gemini 提問 
+## Gemini 回答 
+## Gemini 提問 
+## Gemini 回答 
+## Gemini 提問 
+## Gemini 回答 
+## Gemini 提問 
+## Gemini 回答 
+## Gemini 提問 
+## Gemini 回答 

--- a/electron/ipc/DataTableAPIHandlers.cts
+++ b/electron/ipc/DataTableAPIHandlers.cts
@@ -20,6 +20,12 @@ export const DataTableAPIHandlers: Record<string, IpcMainListener> = {
     }
   ) => {
     const { name, description } = tableInfo;
+
+    const existing = DataTableManager.getTableInfoByName(name);
+    if (existing) {
+      throw new Error(`Table with name ${name} already exists`);
+    }
+
     const directory = FileManager.getUserDataPath("tables");
 
     const fileName = `${Date.now()}_${name}.json`;

--- a/electron/models/DataTableManager.cts
+++ b/electron/models/DataTableManager.cts
@@ -34,6 +34,10 @@ export const DataTableManager = {
     description?: string;
     file_path: string;
   }): DataTableInfo => {
+    const existing = DataTableManager.getTableInfoByName(info.name);
+    if (existing) {
+      throw new Error(`Table with name ${info.name} already exists`);
+    }
     const result = DatabaseManager.run(
       "INSERT INTO tables (name, description, file_path) VALUES (?, ?, ?)",
       [info.name, info.description, info.file_path]

--- a/src/components/DataTablesPage/DataTableList.tsx
+++ b/src/components/DataTablesPage/DataTableList.tsx
@@ -1,4 +1,6 @@
 // src/components/DataTablesPage/DataTableList.tsx
+import { useState } from "react";
+import { useNavigate } from "react-router-dom";
 import {
   Box,
   Card,
@@ -18,11 +20,9 @@ import {
   Link,
 } from "@mui/material";
 import MoreVertIcon from "@mui/icons-material/MoreVert";
-import { useState } from "react";
 import type { DataTableInfo, TableId } from "shared/types/dataTable";
+import type { EditTableNavigateState } from "../../types";
 import { DeleteWarningDialog } from "../common/DeleteWarningDialog";
-import { useNavigate } from "react-router-dom";
-import type { EditTableNavigateState } from "src/types";
 
 interface Props {
   dataTables: DataTableInfo[];

--- a/src/components/DataTablesPage/UploadStatusPanel.tsx
+++ b/src/components/DataTablesPage/UploadStatusPanel.tsx
@@ -1,0 +1,77 @@
+// src/components/DataTablesPage/UploadStatusPanel.tsx
+import React from "react";
+import {
+  Box,
+  Typography,
+  List,
+  ListItem,
+  ListItemText,
+  LinearProgress,
+  Paper,
+} from "@mui/material";
+import CheckCircleIcon from "@mui/icons-material/CheckCircle";
+import ErrorIcon from "@mui/icons-material/Error";
+import CloudUploadIcon from "@mui/icons-material/CloudUpload";
+import {
+  useUploadStore,
+  type FileUploadStatus,
+} from "../../stores/uploadStore";
+
+const getIcon = (status: FileUploadStatus["status"]) => {
+  switch (status) {
+    case "success":
+      return <CheckCircleIcon color="success" sx={{ mr: 1 }} />;
+    case "failed":
+      return <ErrorIcon color="error" sx={{ mr: 1 }} />;
+    case "uploading":
+    default:
+      return <CloudUploadIcon color="primary" sx={{ mr: 1 }} />;
+  }
+};
+
+export const UploadStatusPanel: React.FC = () => {
+  const uploads = useUploadStore((state) => state.uploads);
+
+  if (uploads.length === 0) {
+    return (
+      <Box sx={{ p: 2 }}>
+        <Typography variant="h6">編輯控制面板</Typography>
+        <Typography variant="body2" sx={{ mt: 1 }}>
+          這裡可以添加欄位類型、篩選、排序等控制項。
+        </Typography>
+      </Box>
+    );
+  }
+
+  return (
+    <Box sx={{ p: 2 }}>
+      <Typography variant="h6">上傳狀態</Typography>
+      <List dense sx={{ mt: 1 }}>
+        {uploads.map((upload) => (
+          <Paper key={upload.id} elevation={1} sx={{ mb: 1, p: 1 }}>
+            <ListItem disablePadding>
+              {getIcon(upload.status)}
+              <ListItemText
+                primary={
+                  <Typography variant="body2" sx={{ fontWeight: "bold" }}>
+                    {upload.fileName}
+                  </Typography>
+                }
+                secondary={
+                  <Typography variant="body2" color="text.secondary">
+                    {upload.status === "uploading"
+                      ? "上傳中..."
+                      : upload.status === "success"
+                        ? `上傳成功`
+                        : `上傳失敗: ${upload.error}`}
+                  </Typography>
+                }
+              />
+            </ListItem>
+            {upload.status === "uploading" && <LinearProgress />}
+          </Paper>
+        ))}
+      </List>
+    </Box>
+  );
+};

--- a/src/components/DataTablesPage/UploadStatusPanel.tsx
+++ b/src/components/DataTablesPage/UploadStatusPanel.tsx
@@ -8,10 +8,12 @@ import {
   ListItemText,
   LinearProgress,
   Paper,
+  IconButton,
 } from "@mui/material";
 import CheckCircleIcon from "@mui/icons-material/CheckCircle";
 import ErrorIcon from "@mui/icons-material/Error";
 import CloudUploadIcon from "@mui/icons-material/CloudUpload";
+import CloseIcon from "@mui/icons-material/Close";
 import {
   useUploadStore,
   type FileUploadStatus,
@@ -31,25 +33,32 @@ const getIcon = (status: FileUploadStatus["status"]) => {
 
 export const UploadStatusPanel: React.FC = () => {
   const uploads = useUploadStore((state) => state.uploads);
+  const removeUpload = useUploadStore((state) => state.removeUpload); // 取得移除方法
 
   if (uploads.length === 0) {
-    return (
-      <Box sx={{ p: 2 }}>
-        <Typography variant="h6">編輯控制面板</Typography>
-        <Typography variant="body2" sx={{ mt: 1 }}>
-          這裡可以添加欄位類型、篩選、排序等控制項。
-        </Typography>
-      </Box>
-    );
+    return <Box sx={{ p: 2 }}>這裡可以添加欄位類型、篩選、排序等控制項。</Box>;
   }
 
   return (
     <Box sx={{ p: 2 }}>
-      <Typography variant="h6">上傳狀態</Typography>
       <List dense sx={{ mt: 1 }}>
         {uploads.map((upload) => (
           <Paper key={upload.id} elevation={1} sx={{ mb: 1, p: 1 }}>
-            <ListItem disablePadding>
+            <ListItem
+              disablePadding
+              secondaryAction={
+                (upload.status === "success" || upload.status === "failed") && (
+                  <IconButton
+                    edge="end"
+                    aria-label="delete"
+                    onClick={() => removeUpload(upload.id)}
+                    size="small"
+                  >
+                    <CloseIcon />
+                  </IconButton>
+                )
+              }
+            >
               {getIcon(upload.status)}
               <ListItemText
                 primary={

--- a/src/hooks/useTableDataInitializer.tsx
+++ b/src/hooks/useTableDataInitializer.tsx
@@ -1,9 +1,9 @@
 // src/hooks/useTableDataInitializer.tsx
 import { useState, useEffect } from "react";
+import type { DataTableHeaderSchema, TableId } from "shared/types/dataTable";
+import type { EditorMode } from "../types";
 import { useFileParser } from "./useFileParser";
 import { useTableGetter } from "./useTableGetter";
-import type { DataTableHeaderSchema, TableId } from "shared/types/dataTable";
-import type { EditorMode } from "src/types";
 
 export interface DataTableState {
   data: DataTableHeaderSchema | null;

--- a/src/pages/DataTableEditorPage.tsx
+++ b/src/pages/DataTableEditorPage.tsx
@@ -2,6 +2,8 @@
 import React from "react";
 import { useLocation, useNavigate } from "react-router-dom";
 import { Box, CircularProgress, Alert } from "@mui/material";
+import type { TableId } from "shared/types/dataTable.ts";
+import type { EditorMode } from "../types.tsx";
 import { PageWrapper } from "../components/layout/PageWrapper";
 import EditableTitle from "../components/common/EditableTitle";
 import ConfirmCancelButtons from "../components/common/ConfirmCancelButtons";
@@ -9,8 +11,6 @@ import DataTable from "../components/common/DataTable";
 import PageHeader from "../components/common/PageHeader";
 import { useTableEditor } from "../hooks/useTableEditor";
 import { useTableDataInitializer } from "../hooks/useTableDataInitializer.tsx";
-import type { EditorMode } from "src/types.tsx";
-import type { TableId } from "shared/types/dataTable.ts";
 
 export const DataTableEditorPage: React.FC = () => {
   const location = useLocation();

--- a/src/pages/DataTablesPage.tsx
+++ b/src/pages/DataTablesPage.tsx
@@ -35,7 +35,9 @@ export const DataTablesPage = () => {
 
   // 監聽 uploads 狀態的變化，並在有成功上傳時刷新列表
   useEffect(() => {
+    console.log("Uploads state changed:", uploads);
     if (uploads.some((u) => u.status === "success")) {
+      console.log("Detected successful upload, refreshing table infos...");
       refreshTableInfos();
     }
   }, [uploads]);
@@ -162,7 +164,7 @@ export const DataTablesPage = () => {
       </Box>
     ),
     rightPanelContent: <UploadStatusPanel />, // 這裡使用新元件
-    rightPanelTitle: uploads.length > 0 ? "上傳狀態" : "編輯控制面板",
+    rightPanelTitle: "上傳狀態",
   };
 
   return <PageWrapper {...pageConfig} />;

--- a/src/pages/DataTablesPage.tsx
+++ b/src/pages/DataTablesPage.tsx
@@ -17,21 +17,36 @@ import GridViewIcon from "@mui/icons-material/GridView";
 import { PageWrapper } from "../components/layout/PageWrapper";
 import { DataTableList } from "../components/DataTablesPage/DataTableList";
 import { UploadDataTableDialog } from "../components/DataTablesPage/UploadDataTableDialog";
+import { useUploadStore } from "../stores/uploadStore";
 import type { DataTableInfo } from "shared/types/dataTable";
 import type { CreateTableNavigateState, PageConfig } from "../types";
+import { UploadStatusPanel } from "../components/DataTablesPage/UploadStatusPanel"; // 新增元件
 
 export const DataTablesPage = () => {
   const [searchText, setSearchText] = useState("");
   const [uploadDialogOpen, setUploadDialogOpen] = useState(false);
   const [viewMode, setViewMode] = useState<"card" | "list">("card");
-  const [tableInfos, setTableInfos] = useState<DataTableInfo[]>([]); // 真正從後端來的資料
+  const [tableInfos, setTableInfos] = useState<DataTableInfo[]>([]);
   const navigate = useNavigate();
-  console.log("DataTablesPage");
+
+  // 從 Zustand Store 獲取上傳狀態
+  const uploads = useUploadStore((state) => state.uploads);
+  const resetUploads = useUploadStore((state) => state.reset);
+
+  // 監聽 uploads 狀態的變化，並在有成功上傳時刷新列表
+  useEffect(() => {
+    if (uploads.some((u) => u.status === "success")) {
+      refreshTableInfos();
+    }
+  }, [uploads]);
 
   useEffect(() => {
-    // 載入後端資料表資訊
     refreshTableInfos();
-  }, []);
+    // 頁面初次載入時清空上傳狀態，避免上次的紀錄影響本次
+    return () => {
+      resetUploads();
+    };
+  }, [resetUploads]);
 
   const refreshTableInfos = () => {
     window.api.getAllTableInfos().then((tables) => {
@@ -48,7 +63,6 @@ export const DataTablesPage = () => {
     _event: React.MouseEvent<HTMLElement>,
     newViewMode: "card" | "list"
   ) => {
-    // 只有當新模式不為 null 時才更新狀態
     if (newViewMode !== null) {
       setViewMode(newViewMode);
     }
@@ -133,7 +147,7 @@ export const DataTablesPage = () => {
           </Grid>
         </Grid>
 
-        {/* 將 viewMode 作為 props 傳遞給 DataTableList */}
+        {/* 資料表格列表 */}
         <DataTableList
           dataTables={filteredDataTables}
           viewMode={viewMode}
@@ -147,6 +161,8 @@ export const DataTablesPage = () => {
         />
       </Box>
     ),
+    rightPanelContent: <UploadStatusPanel />, // 這裡使用新元件
+    rightPanelTitle: uploads.length > 0 ? "上傳狀態" : "編輯控制面板",
   };
 
   return <PageWrapper {...pageConfig} />;

--- a/src/stores/uploadStore.ts
+++ b/src/stores/uploadStore.ts
@@ -5,19 +5,20 @@ import { parseDataFile } from "../utils";
 import type { DataTableInfo } from "shared/types/dataTable";
 
 export interface FileUploadStatus {
-  id: string; // 使用檔案名稱作為唯一 ID
+  id: string; // 使用檔案名稱加時間戳加隨機數作為唯一 ID
   fileName: string;
   status: "uploading" | "success" | "failed";
   progress?: number;
   error?: string;
   info?: DataTableInfo;
+  timeoutId?: ReturnType<typeof setTimeout>; // 用於儲存定時器 ID
 }
 
 interface UploadState {
   uploads: FileUploadStatus[];
-  addUpload: (file: File) => void;
+  addUpload: (file: File) => string; // 回傳新建立的 ID
   updateUploadStatus: (
-    fileName: string,
+    id: string,
     status: FileUploadStatus["status"],
     info?: DataTableInfo,
     error?: string
@@ -25,6 +26,7 @@ interface UploadState {
   // 處理上傳檔案的非同步邏輯
   startUploads: (files: File[]) => Promise<void>;
   reset: () => void;
+  removeUpload: (id: string) => void; // 新增移除方法
 }
 
 export const useUploadStore = create<UploadState>()(
@@ -33,32 +35,37 @@ export const useUploadStore = create<UploadState>()(
       uploads: [],
 
       addUpload: (file: File) => {
+        const newId = `${file.name}-${Date.now()}-${Math.random().toString(36).substr(2, 9)}`;
         set((state) => ({
           uploads: [
             ...state.uploads,
-            { id: file.name, fileName: file.name, status: "uploading" },
+            { id: newId, fileName: file.name, status: "uploading" },
           ],
         }));
+        return newId;
       },
 
-      updateUploadStatus: (fileName, status, info, error) => {
+      updateUploadStatus: (id, status, info, error) => {
         set((state) => ({
           uploads: state.uploads.map((upload) =>
-            upload.fileName === fileName
-              ? { ...upload, status, info, error }
-              : upload
+            upload.id === id ? { ...upload, status, info, error } : upload
           ),
         }));
       },
 
+      removeUpload: (id) => {
+        set((state) => ({
+          uploads: state.uploads.filter((upload) => upload.id !== id),
+        }));
+      },
+
       startUploads: async (files: File[]) => {
-        const { updateUploadStatus, addUpload } = get();
+        const { updateUploadStatus, addUpload, removeUpload } = get();
 
         // 遍歷所有檔案並開始上傳
         for (const file of files) {
-          addUpload(file);
+          const newId = addUpload(file);
           try {
-            // 模擬解析檔案
             const parsedData = await parseDataFile(file);
             // 呼叫後端 API
             const tableInfo = {
@@ -70,12 +77,20 @@ export const useUploadStore = create<UploadState>()(
               parsedData
             );
             // 更新狀態為成功
-            updateUploadStatus(file.name, "success", dataTableInfo);
+            updateUploadStatus(newId, "success", dataTableInfo);
+            // 成功後設定定時器
+            setTimeout(() => {
+              removeUpload(newId);
+            }, 10000); // 10 秒後自動移除
           } catch (e: unknown) {
             console.error(`上傳 ${file.name} 失敗:`, e);
             const errorMsg = e instanceof Error ? e.message : "未知錯誤";
             // 更新狀態為失敗
-            updateUploadStatus(file.name, "failed", undefined, errorMsg);
+            updateUploadStatus(newId, "failed", undefined, errorMsg);
+            // 失敗後設定定時器
+            setTimeout(() => {
+              removeUpload(newId);
+            }, 30000); // 30 秒後自動移除
           }
         }
       },

--- a/src/stores/uploadStore.ts
+++ b/src/stores/uploadStore.ts
@@ -1,0 +1,89 @@
+// src/stores/uploadStore.ts
+import { create } from "zustand";
+import { devtools } from "zustand/middleware";
+import { parseDataFile } from "../utils";
+import type { DataTableInfo } from "shared/types/dataTable";
+
+export interface FileUploadStatus {
+  id: string; // 使用檔案名稱作為唯一 ID
+  fileName: string;
+  status: "uploading" | "success" | "failed";
+  progress?: number;
+  error?: string;
+  info?: DataTableInfo;
+}
+
+interface UploadState {
+  uploads: FileUploadStatus[];
+  addUpload: (file: File) => void;
+  updateUploadStatus: (
+    fileName: string,
+    status: FileUploadStatus["status"],
+    info?: DataTableInfo,
+    error?: string
+  ) => void;
+  // 處理上傳檔案的非同步邏輯
+  startUploads: (files: File[]) => Promise<void>;
+  reset: () => void;
+}
+
+export const useUploadStore = create<UploadState>()(
+  devtools(
+    (set, get) => ({
+      uploads: [],
+
+      addUpload: (file: File) => {
+        set((state) => ({
+          uploads: [
+            ...state.uploads,
+            { id: file.name, fileName: file.name, status: "uploading" },
+          ],
+        }));
+      },
+
+      updateUploadStatus: (fileName, status, info, error) => {
+        set((state) => ({
+          uploads: state.uploads.map((upload) =>
+            upload.fileName === fileName
+              ? { ...upload, status, info, error }
+              : upload
+          ),
+        }));
+      },
+
+      startUploads: async (files: File[]) => {
+        const { updateUploadStatus, addUpload } = get();
+
+        // 遍歷所有檔案並開始上傳
+        for (const file of files) {
+          addUpload(file);
+          try {
+            // 模擬解析檔案
+            const parsedData = await parseDataFile(file);
+            // 呼叫後端 API
+            const tableInfo = {
+              name: file.name.split(".")[0],
+              description: "",
+            };
+            const dataTableInfo = await window.api.uploadTable(
+              tableInfo,
+              parsedData
+            );
+            // 更新狀態為成功
+            updateUploadStatus(file.name, "success", dataTableInfo);
+          } catch (e: unknown) {
+            console.error(`上傳 ${file.name} 失敗:`, e);
+            const errorMsg = e instanceof Error ? e.message : "未知錯誤";
+            // 更新狀態為失敗
+            updateUploadStatus(file.name, "failed", undefined, errorMsg);
+          }
+        }
+      },
+
+      reset: () => {
+        set({ uploads: [] });
+      },
+    }),
+    { name: "upload-store" } // 開發者工具名稱
+  )
+);


### PR DESCRIPTION
feat(upload, dataTable, ui, store, types): add upload management flow with status panel and prevent duplicate table creation

## ✨ Features

* **Upload Store** (`uploadStore.ts`):

  * Added Zustand store to manage file uploads.
  * Tracks status (`uploading`, `success`, `failed`).
  * Supports add/update/reset operations.
  * Integrated with backend API and file parser.
  * Auto-remove uploads (success after 10s, failed after 30s).

* **UI – Upload Status Panel** (`UploadStatusPanel.tsx`):

  * Displays upload progress and results with icons and messages.
  * Supports manual removal of completed/failed uploads.
  * Integrated into `DataTablesPage` as right panel content.

* **Upload Flow Integration** (`UploadDataTableDialog.tsx`, `DataTablesPage.tsx`):

  * Single file upload → navigate to editor.
  * Multiple file uploads → handled asynchronously via store.
  * Auto-refresh table list on successful uploads.
  * Panel title consistently shows **"Upload Status"**.

* **DataTable Validations** (`DataTableAPIHandlers.cts`, `DataTableManager.cts`):

  * Prevent creation of tables with duplicate names.
  * Explicit error thrown when conflict occurs.

## 🔧 Refactor

* Unified type import paths:

  * Local types (`../types`) vs shared types (`shared/types`).
  * Updated in `DataTableList`, `useTableDataInitializer`, `DataTableEditorPage`.

---

feat(upload, dataTable, ui, store, types): 新增上傳管理流程與狀態面板，並防止重複資料表建立

## ✨ 功能新增

* **上傳 Store** (`uploadStore.ts`)：

  * 使用 Zustand 建立檔案上傳管理。
  * 追蹤狀態（`uploading`、`success`、`failed`）。
  * 支援新增、更新、重置上傳紀錄。
  * 整合後端 API 與檔案解析。
  * 自動移除上傳紀錄（成功 10 秒後、失敗 30 秒後）。

* **UI – 上傳狀態面板** (`UploadStatusPanel.tsx`)：

  * 以圖示與訊息顯示上傳進度與結果。
  * 已完成或失敗的上傳可手動刪除。
  * 整合至 `DataTablesPage` 右側面板。

* **上傳流程整合** (`UploadDataTableDialog.tsx`, `DataTablesPage.tsx`)：

  * 單一檔案 → 導向編輯頁面。
  * 多檔案 → 透過 store 非同步處理。
  * 成功上傳後自動刷新資料表列表。
  * 右側面板標題固定為「上傳狀態」。

* **資料表驗證** (`DataTableAPIHandlers.cts`, `DataTableManager.cts`)：

  * 建立資料表前檢查名稱唯一性。
  * 若名稱重複則丟出明確錯誤。

## 🔧 重構

* 統一路徑匯入：

  * 區分 shared types 與 local types。
  * 調整於 `DataTableList`、`useTableDataInitializer`、`DataTableEditorPage`。
