### PR TITLE
feat(upload): Enhance upload status panel with expandable details (#40)

### DIFF
--- a/docs/專案提示詞紀錄/專案提示詞紀錄-11.md
+++ b/docs/專案提示詞紀錄/專案提示詞紀錄-11.md
@@ -1,5 +1,5 @@
 ## Gemini+ChatGPT 提問 DataTableEditorPage三種模式
-> 開新一頁
+> 另開新一頁
 你是一名專業的全端桌面軟體程式設計師，有多年使用 Electron + React 的豐富經驗，現在面對以下專案和問題
 
 🧩 專案背景：

--- a/docs/專案提示詞紀錄/專案提示詞紀錄-12.md
+++ b/docs/專案提示詞紀錄/專案提示詞紀錄-12.md
@@ -228,8 +228,550 @@ export const UploadStatusPanel: React.FC = () => {
 
 這三個優化使得多檔案上傳功能更加健壯和人性化，提供了更好的使用者體驗。
 
-## Gemini 提問 
-## Gemini 回答 
+## Gemini 提問 資料表多重上傳-狀態條摺疊
+> 另開新一頁
+
+🧩 專案背景：
+- 使用技術：
+  - 前端 Vite + React + MUI + Zustand + TypeScript
+  - 後端 Electron + better-sqlite3
+- 專案類型：資料視覺化儀表板
+- 目前架構：
+```front end
+  src/
+  ├── assets/data.json, snake.jpg
+  ├── components/common/ConfirmCancelButtons.tsx, DataTable.tsx, DeleteWarningDialog.tsx, EditableCell.tsx, EditableTitle.tsx, Logo.tsx, PageHeader.tsx, SimpleTable.tsx
+  ├── components/DataTablesPage/DataTableList.tsx, UploadDataTableDialog.tsx, UploadStatusPanel.tsx
+  ├── components/layout/Breadcrumb.tsx, layout.css, Layout.tsx, PageWrapper.tsx, RightPanel.tsx, Sidebar.tsx, TocList.tsx, TocListItem.tsx, TopNav.tsx
+  ├── context/LayoutContext.tsx, LayoutProvider.tsx, useLayoutContext.tsx
+  ├── hooks/useFileParser.tsx, useTableDataInitializer.tsx, useTableEditor.tsx, useTableGetter.tsx
+  ├── pages/ChartEditorPage.tsx, ChartsPage.tsx, ChartViewPage.tsx, DashboardPage.tsx, DashboardsPage.tsx, DataTableEditorPage.tsx, DataTablesPage.tsx, DownloadPage.tsx, HomePage.tsx, TestingPage.tsx, UploadPage.tsx
+  ├── stores/layoutStore.ts, uploadStore.ts
+  ├── theme/index.ts
+  ├── App.tsx
+  ├── main.tsx
+  ├── mui.d.ts
+  ├── preload.d.ts
+  ├── types.tsx
+  ├── utils.tsx
+  └── vite-env.d.ts
+```
+```backend
+  electron/
+  ├── ipc/APIModule.cts, ChartAPIHandlers.cts, DashboardAPIHandlers.cts, DataTableAPIHandlers.cts
+  ├── models/ChartManager.cts, DatabaseManager.cts, DataTableManager.cts, FileManager.cts
+  ├── node_modules/.tmp/tsconfig.electron.tsbuildinfo
+  ├── services/DataTableService.cts
+  ├── windows/mainWindow.cts
+  ├── constants.cts
+  ├── main.cts
+  ├── preload.cts
+  ├── tsconfig.json
+  ├── types.cts
+  └── utils.cts
+```
+
+🧱 已完成項目：
+- ipc: 綁定 DataTable 資料表相關 API
+- 使用 PageWrapper 完成排版相關的包裝
+- useTableGetter 自定義 Hook 處理從後端 API 獲取資料表格邏輯
+- useFileParser 自定義 Hook 處理資料表格檔案解析邏輯
+- 實現"從後端 API 獲取資料表格"、"使用者上傳資料表格檔案"、"使用者建立空白資料表格"三種模式進入表格編輯頁面 DataTableEditorPage
+
+🔧 目前狀態：
+- uploadStore 一個 Zustand Store，用於儲存所有正在上傳或已上傳完成的檔案及其狀態
+- UploadStatusPanel 從 Zustand Store 讀取上傳狀態，並渲染到右側邊欄
+
+❓接下來想處理的問題：
+希望將當前狀態條改為摺疊模式，預設顯示為收合狀態，僅包含圖示、檔案名稱、上傳狀態及刪除按鈕。使用者可點擊展開查看詳情，展開後除了前述資訊外，還需顯示上傳失敗的錯誤原因描述。
+
+
+相關檔案：
+```tsx
+// src/stores/uploadStore.ts
+import { create } from "zustand";
+import { devtools } from "zustand/middleware";
+import { parseDataFile } from "../utils";
+import type { DataTableInfo } from "shared/types/dataTable";
+
+export interface FileUploadStatus {
+  id: string; // 使用檔案名稱加時間戳加隨機數作為唯一 ID
+  fileName: string;
+  status: "uploading" | "success" | "failed";
+  progress?: number;
+  error?: string;
+  info?: DataTableInfo;
+  timeoutId?: ReturnType<typeof setTimeout>; // 用於儲存定時器 ID
+}
+
+interface UploadState {
+  uploads: FileUploadStatus[];
+  addUpload: (file: File) => string; // 回傳新建立的 ID
+  updateUploadStatus: (
+    id: string,
+    status: FileUploadStatus["status"],
+    info?: DataTableInfo,
+    error?: string
+  ) => void;
+  // 處理上傳檔案的非同步邏輯
+  startUploads: (files: File[]) => Promise<void>;
+  reset: () => void;
+  removeUpload: (id: string) => void; // 新增移除方法
+}
+
+export const useUploadStore = create<UploadState>()(
+  devtools(
+    (set, get) => ({
+      uploads: [],
+
+      addUpload: (file: File) => {
+        const newId = `${file.name}-${Date.now()}-${Math.random().toString(36).substr(2, 9)}`;
+        set((state) => ({
+          uploads: [
+            ...state.uploads,
+            { id: newId, fileName: file.name, status: "uploading" },
+          ],
+        }));
+        return newId;
+      },
+
+      updateUploadStatus: (id, status, info, error) => {
+        set((state) => ({
+          uploads: state.uploads.map((upload) =>
+            upload.id === id ? { ...upload, status, info, error } : upload
+          ),
+        }));
+      },
+
+      removeUpload: (id) => {
+        set((state) => ({
+          uploads: state.uploads.filter((upload) => upload.id !== id),
+        }));
+      },
+
+      startUploads: async (files: File[]) => {
+        const { updateUploadStatus, addUpload, removeUpload } = get();
+
+        // 遍歷所有檔案並開始上傳
+        for (const file of files) {
+          const newId = addUpload(file);
+          try {
+            const parsedData = await parseDataFile(file);
+            // 呼叫後端 API
+            const tableInfo = {
+              name: file.name.split(".")[0],
+              description: "",
+            };
+            const dataTableInfo = await window.api.uploadTable(
+              tableInfo,
+              parsedData
+            );
+            // 更新狀態為成功
+            updateUploadStatus(newId, "success", dataTableInfo);
+            // 成功後設定定時器
+            setTimeout(() => {
+              removeUpload(newId);
+            }, 10000); // 10 秒後自動移除
+          } catch (e: unknown) {
+            console.error(`上傳 ${file.name} 失敗:`, e);
+            const errorMsg = e instanceof Error ? e.message : "未知錯誤";
+            // 更新狀態為失敗
+            updateUploadStatus(newId, "failed", undefined, errorMsg);
+            // 失敗後設定定時器
+            setTimeout(() => {
+              removeUpload(newId);
+            }, 30000); // 30 秒後自動移除
+          }
+        }
+      },
+
+      reset: () => {
+        set({ uploads: [] });
+      },
+    }),
+    { name: "upload-store" } // 開發者工具名稱
+  )
+);
+```
+
+```tsx
+// src/components/DataTablesPage/UploadStatusPanel.tsx
+import React from "react";
+import {
+  Box,
+  Typography,
+  List,
+  ListItem,
+  ListItemText,
+  LinearProgress,
+  Paper,
+  IconButton,
+} from "@mui/material";
+import CheckCircleIcon from "@mui/icons-material/CheckCircle";
+import ErrorIcon from "@mui/icons-material/Error";
+import CloudUploadIcon from "@mui/icons-material/CloudUpload";
+import CloseIcon from "@mui/icons-material/Close";
+import {
+  useUploadStore,
+  type FileUploadStatus,
+} from "../../stores/uploadStore";
+
+const getIcon = (status: FileUploadStatus["status"]) => {
+  switch (status) {
+    case "success":
+      return <CheckCircleIcon color="success" sx={{ mr: 1 }} />;
+    case "failed":
+      return <ErrorIcon color="error" sx={{ mr: 1 }} />;
+    case "uploading":
+    default:
+      return <CloudUploadIcon color="primary" sx={{ mr: 1 }} />;
+  }
+};
+
+export const UploadStatusPanel: React.FC = () => {
+  const uploads = useUploadStore((state) => state.uploads);
+  const removeUpload = useUploadStore((state) => state.removeUpload); // 取得移除方法
+
+  if (uploads.length === 0) {
+    return <Box sx={{ p: 2 }}>這裡可以添加欄位類型、篩選、排序等控制項。</Box>;
+  }
+
+  return (
+    <Box sx={{ p: 2 }}>
+      <List dense sx={{ mt: 1 }}>
+        {uploads.map((upload) => (
+          <Paper key={upload.id} elevation={1} sx={{ mb: 1, p: 1 }}>
+            <ListItem
+              disablePadding
+              secondaryAction={
+                (upload.status === "success" || upload.status === "failed") && (
+                  <IconButton
+                    edge="end"
+                    aria-label="delete"
+                    onClick={() => removeUpload(upload.id)}
+                    size="small"
+                  >
+                    <CloseIcon />
+                  </IconButton>
+                )
+              }
+            >
+              {getIcon(upload.status)}
+              <ListItemText
+                primary={
+                  <Typography variant="body2" sx={{ fontWeight: "bold" }}>
+                    {upload.fileName}
+                  </Typography>
+                }
+                secondary={
+                  <Typography variant="body2" color="text.secondary">
+                    {upload.status === "uploading"
+                      ? "上傳中..."
+                      : upload.status === "success"
+                        ? `上傳成功`
+                        : `上傳失敗: ${upload.error}`}
+                  </Typography>
+                }
+              />
+            </ListItem>
+            {upload.status === "uploading" && <LinearProgress />}
+          </Paper>
+        ))}
+      </List>
+    </Box>
+  );
+};
+```
+
+
+## Gemini 回答 資料表多重上傳-狀態條摺疊
+這是一個很棒的需求，將上傳狀態面板改為摺疊模式，不僅能節省空間，也能讓介面更簡潔，同時在需要時提供詳細資訊。
+
+要實現這個功能，我們可以利用 Material-UI 的 **`Accordion`** 或 **`Collapse`** 元件，並在 Zustand store 中新增一個狀態來追蹤每個上傳項目的展開/收合狀態。
+
+-----
+
+### 步驟 1：修改 Zustand Store
+
+首先，我們需要在 `FileUploadStatus` 介面中加入一個新屬性來追蹤摺疊狀態。這個屬性會是可選的，以便與舊資料相容。
+
+```tsx
+// src/stores/uploadStore.ts
+// ... (保留現有程式碼)
+
+export interface FileUploadStatus {
+  id: string;
+  fileName: string;
+  status: "uploading" | "success" | "failed";
+  progress?: number;
+  error?: string;
+  info?: DataTableInfo;
+  timeoutId?: ReturnType<typeof setTimeout>;
+  isExpanded?: boolean; // 新增摺疊狀態屬性
+}
+
+interface UploadState {
+  uploads: FileUploadStatus[];
+  addUpload: (file: File) => string;
+  updateUploadStatus: (
+    id: string,
+    status: FileUploadStatus["status"],
+    info?: DataTableInfo,
+    error?: string
+  ) => void;
+  startUploads: (files: File[]) => Promise<void>;
+  reset: () => void;
+  removeUpload: (id: string) => void;
+  toggleExpand: (id: string) => void; // 新增切換展開狀態的方法
+}
+
+export const useUploadStore = create<UploadState>()(
+  devtools(
+    (set, get) => ({
+      uploads: [],
+
+      addUpload: (file: File) => {
+        const newId = `${file.name}-${Date.now()}-${Math.random()
+          .toString(36)
+          .substr(2, 9)}`;
+        set((state) => ({
+          uploads: [
+            ...state.uploads,
+            { id: newId, fileName: file.name, status: "uploading", isExpanded: false }, // 初始化為收合狀態
+          ],
+        }));
+        return newId;
+      },
+
+      updateUploadStatus: (id, status, info, error) => {
+        set((state) => ({
+          uploads: state.uploads.map((upload) =>
+            upload.id === id ? { ...upload, status, info, error, isExpanded: false } : upload
+          ),
+        }));
+      },
+
+      removeUpload: (id) => {
+        set((state) => ({
+          uploads: state.uploads.filter((upload) => upload.id !== id),
+        }));
+      },
+
+      toggleExpand: (id) => {
+        set((state) => ({
+          uploads: state.uploads.map((upload) =>
+            upload.id === id ? { ...upload, isExpanded: !upload.isExpanded } : upload
+          ),
+        }));
+      },
+
+      startUploads: async (files: File[]) => {
+        const { updateUploadStatus, addUpload, removeUpload } = get();
+        // ... (保持現有的 startUploads 邏輯)
+        for (const file of files) {
+          const newId = addUpload(file);
+          try {
+            const parsedData = await parseDataFile(file);
+            const tableInfo = {
+              name: file.name.split(".")[0],
+              description: "",
+            };
+            const dataTableInfo = await window.api.uploadTable(
+              tableInfo,
+              parsedData
+            );
+            updateUploadStatus(newId, "success", dataTableInfo);
+            setTimeout(() => {
+              removeUpload(newId);
+            }, 10000);
+          } catch (e: unknown) {
+            console.error(`上傳 ${file.name} 失敗:`, e);
+            const errorMsg = e instanceof Error ? e.message : "未知錯誤";
+            updateUploadStatus(newId, "failed", undefined, errorMsg);
+            setTimeout(() => {
+              removeUpload(newId);
+            }, 30000);
+          }
+        }
+      },
+
+      reset: () => {
+        set({ uploads: [] });
+      },
+    }),
+    { name: "upload-store" }
+  )
+);
+```
+
+### 步驟 2：修改 `UploadStatusPanel.tsx`
+
+接下來，我們將使用 Material-UI 的 **`Accordion`** 元件來重構 `UploadStatusPanel.tsx`，以實現摺疊效果。每個上傳項目都將變成一個獨立的 `Accordion`。
+
+  - **`AccordionSummary`** 用於顯示摺疊狀態下的內容（圖示、檔案名稱、上傳狀態、刪除按鈕）。
+  - **`AccordionDetails`** 用於顯示展開後的詳細內容（錯誤原因）。
+
+我們還需要從 Zustand store 中獲取 `toggleExpand` 方法，並綁定到 `Accordion` 的 `onChange` 事件上。
+
+```tsx
+// src/components/DataTablesPage/UploadStatusPanel.tsx
+import React from "react";
+import {
+  Box,
+  Typography,
+  List,
+  ListItem,
+  ListItemText,
+  LinearProgress,
+  Paper,
+  IconButton,
+  Accordion, // 引入 Accordion
+  AccordionSummary, // 引入 AccordionSummary
+  AccordionDetails, // 引入 AccordionDetails
+  ListItemIcon, // 引入 ListItemIcon
+} from "@mui/material";
+import CheckCircleIcon from "@mui/icons-material/CheckCircle";
+import ErrorIcon from "@mui/icons-material/Error";
+import CloudUploadIcon from "@mui/icons-material/CloudUpload";
+import CloseIcon from "@mui/icons-material/Close";
+import ExpandMoreIcon from "@mui/icons-material/ExpandMore"; // 引入展開/收合圖示
+
+import {
+  useUploadStore,
+  type FileUploadStatus,
+} from "../../stores/uploadStore";
+
+// 狀態圖示
+const getIcon = (status: FileUploadStatus["status"]) => {
+  switch (status) {
+    case "success":
+      return <CheckCircleIcon color="success" />;
+    case "failed":
+      return <ErrorIcon color="error" />;
+    case "uploading":
+    default:
+      return <CloudUploadIcon color="primary" />;
+  }
+};
+
+export const UploadStatusPanel: React.FC = () => {
+  const uploads = useUploadStore((state) => state.uploads);
+  const removeUpload = useUploadStore((state) => state.removeUpload);
+  const toggleExpand = useUploadStore((state) => state.toggleExpand); // 取得切換方法
+
+  if (uploads.length === 0) {
+    return (
+      <Box sx={{ p: 2, color: "text.secondary" }}>
+        上傳狀態會顯示在這裡。
+      </Box>
+    );
+  }
+
+  return (
+    <Box sx={{ p: 2 }}>
+      <Typography variant="h6" gutterBottom>
+        上傳狀態
+      </Typography>
+      <List dense sx={{ mt: 1 }}>
+        {uploads.map((upload) => (
+          <Paper key={upload.id} elevation={1} sx={{ mb: 1 }}>
+            <Accordion
+              expanded={upload.isExpanded}
+              onChange={() => toggleExpand(upload.id)}
+              sx={{
+                "&.MuiAccordion-root": {
+                  boxShadow: "none",
+                  "&::before": { display: "none" },
+                },
+              }}
+            >
+              <AccordionSummary
+                expandIcon={<ExpandMoreIcon />}
+                aria-controls={`panel-${upload.id}-content`}
+                id={`panel-${upload.id}-header`}
+                sx={{
+                  minHeight: "48px",
+                  "&.Mui-expanded": { minHeight: "48px" },
+                  "& .MuiAccordionSummary-content": {
+                    alignItems: "center",
+                    margin: "12px 0",
+                    "&.Mui-expanded": { margin: "12px 0" },
+                  },
+                }}
+              >
+                <ListItemIcon sx={{ minWidth: "40px" }}>
+                  {getIcon(upload.status)}
+                </ListItemIcon>
+                <ListItemText
+                  primary={
+                    <Typography variant="body2" sx={{ fontWeight: "bold" }}>
+                      {upload.fileName}
+                    </Typography>
+                  }
+                  secondary={
+                    <Typography variant="body2" color="text.secondary">
+                      {upload.status === "uploading"
+                        ? "上傳中..."
+                        : upload.status === "success"
+                        ? "上傳成功"
+                        : "上傳失敗"}
+                    </Typography>
+                  }
+                />
+                {(upload.status === "success" || upload.status === "failed") && (
+                  <IconButton
+                    edge="end"
+                    aria-label="delete"
+                    onClick={(e) => {
+                      e.stopPropagation(); // 阻止事件冒泡到 AccordionSummary
+                      removeUpload(upload.id);
+                    }}
+                    size="small"
+                    sx={{ ml: 1 }}
+                  >
+                    <CloseIcon />
+                  </IconButton>
+                )}
+              </AccordionSummary>
+              <AccordionDetails>
+                {upload.status === "uploading" && <LinearProgress />}
+                {upload.status === "failed" && (
+                  <Box sx={{ mt: 1, p: 1, backgroundColor: "rgba(255, 0, 0, 0.05)", borderRadius: 1 }}>
+                    <Typography variant="body2" color="error">
+                      錯誤原因: {upload.error}
+                    </Typography>
+                  </Box>
+                )}
+              </AccordionDetails>
+            </Accordion>
+          </Paper>
+        ))}
+      </List>
+    </Box>
+  );
+};
+```
+
+-----
+
+### 重構重點說明
+
+1.  **狀態管理**: 在 `useUploadStore` 中新增 `isExpanded` 屬性，並提供 `toggleExpand` 方法，將摺疊狀態的邏輯集中管理，確保 UI 和狀態同步。
+2.  **MUI 元件應用**:
+      - 使用 `<Accordion>` 包裝每個上傳項目。
+      - `<AccordionSummary>` 作為摺疊後的顯示區塊，包含基本資訊和展開圖示。
+      - `<AccordionDetails>` 則用於顯示展開後的詳細內容，例如上傳進度條或錯誤訊息。
+3.  **事件處理**:
+      - `<Accordion>` 的 `expanded` 屬性綁定到 `upload.isExpanded`，使其受控於 Zustand store。
+      - `onChange` 事件則觸發 `toggleExpand(upload.id)` 來更新狀態。
+      - **注意**：在 `<IconButton>` 的 `onClick` 事件中加入 `e.stopPropagation()`，可以避免點擊刪除按鈕時，同時觸發 `Accordion` 的展開/收合事件。
+4.  **UI 邏輯**:
+      - 刪除按鈕只在上傳成功或失敗時顯示。
+      - 進度條只在上傳中時顯示。
+      - 錯誤原因描述只在失敗時顯示，並包裝在一個有背景色的 Box 中，以突出顯示。
+
+透過這些修改，您的上傳狀態面板將更具使用者友好性，並有效管理介面空間。
+
 ## Gemini 提問 
 ## Gemini 回答 
 ## Gemini 提問 

--- a/src/components/DataTablesPage/UploadStatusPanel.tsx
+++ b/src/components/DataTablesPage/UploadStatusPanel.tsx
@@ -4,11 +4,14 @@ import {
   Box,
   Typography,
   List,
-  ListItem,
   ListItemText,
   LinearProgress,
   Paper,
   IconButton,
+  AccordionDetails,
+  Accordion,
+  AccordionSummary,
+  ListItemIcon,
 } from "@mui/material";
 import CheckCircleIcon from "@mui/icons-material/CheckCircle";
 import ErrorIcon from "@mui/icons-material/Error";
@@ -33,51 +36,96 @@ const getIcon = (status: FileUploadStatus["status"]) => {
 
 export const UploadStatusPanel: React.FC = () => {
   const uploads = useUploadStore((state) => state.uploads);
-  const removeUpload = useUploadStore((state) => state.removeUpload); // 取得移除方法
+  const removeUpload = useUploadStore((state) => state.removeUpload);
+  const toggleExpand = useUploadStore((state) => state.toggleExpand);
 
   if (uploads.length === 0) {
-    return <Box sx={{ p: 2 }}>這裡可以添加欄位類型、篩選、排序等控制項。</Box>;
+    return (
+      <Box sx={{ p: 2, color: "text.secondary" }}>上傳狀態會顯示在這裡。</Box>
+    );
   }
 
   return (
     <Box sx={{ p: 2 }}>
       <List dense sx={{ mt: 1 }}>
         {uploads.map((upload) => (
-          <Paper key={upload.id} elevation={1} sx={{ mb: 1, p: 1 }}>
-            <ListItem
-              disablePadding
-              secondaryAction={
-                (upload.status === "success" || upload.status === "failed") && (
+          <Paper key={upload.id} elevation={1} sx={{ mb: 1 }}>
+            <Accordion
+              expanded={upload.isExpanded}
+              onChange={() => toggleExpand(upload.id)}
+              sx={{
+                "&.MuiAccordion-root": {
+                  boxShadow: "none",
+                  "&::before": { display: "none" },
+                },
+              }}
+            >
+              <AccordionSummary
+                aria-controls={`panel-${upload.id}-content`}
+                id={`panel-${upload.id}-header`}
+                sx={{
+                  minHeight: "48px",
+                  "&.Mui-expanded": { minHeight: "48px" },
+                  "& .MuiAccordionSummary-content": {
+                    alignItems: "center",
+                    margin: "12px 0",
+                    "&.Mui-expanded": { margin: "12px 0" },
+                  },
+                }}
+              >
+                <ListItemIcon sx={{ minWidth: "40px" }}>
+                  {getIcon(upload.status)}
+                </ListItemIcon>
+                <ListItemText
+                  primary={
+                    <Typography variant="body2" sx={{ fontWeight: "bold" }}>
+                      {upload.fileName}
+                    </Typography>
+                  }
+                  secondary={
+                    <Typography variant="body2" color="text.secondary">
+                      {upload.status === "uploading"
+                        ? "上傳中..."
+                        : upload.status === "success"
+                          ? "上傳成功"
+                          : "上傳失敗"}
+                    </Typography>
+                  }
+                />
+                {(upload.status === "success" ||
+                  upload.status === "failed") && (
                   <IconButton
                     edge="end"
                     aria-label="delete"
-                    onClick={() => removeUpload(upload.id)}
+                    onClick={(e) => {
+                      e.stopPropagation(); // 阻止事件冒泡到 AccordionSummary
+                      removeUpload(upload.id);
+                    }}
                     size="small"
+                    sx={{ ml: 1 }}
                   >
                     <CloseIcon />
                   </IconButton>
-                )
-              }
-            >
-              {getIcon(upload.status)}
-              <ListItemText
-                primary={
-                  <Typography variant="body2" sx={{ fontWeight: "bold" }}>
-                    {upload.fileName}
-                  </Typography>
-                }
-                secondary={
-                  <Typography variant="body2" color="text.secondary">
-                    {upload.status === "uploading"
-                      ? "上傳中..."
-                      : upload.status === "success"
-                        ? `上傳成功`
-                        : `上傳失敗: ${upload.error}`}
-                  </Typography>
-                }
-              />
-            </ListItem>
-            {upload.status === "uploading" && <LinearProgress />}
+                )}
+              </AccordionSummary>
+              <AccordionDetails>
+                {upload.status === "uploading" && <LinearProgress />}
+                {upload.status === "failed" && (
+                  <Box
+                    sx={{
+                      mt: 1,
+                      p: 1,
+                      backgroundColor: "rgba(255, 0, 0, 0.05)",
+                      borderRadius: 1,
+                    }}
+                  >
+                    <Typography variant="body2" color="error">
+                      錯誤原因: {upload.error}
+                    </Typography>
+                  </Box>
+                )}
+              </AccordionDetails>
+            </Accordion>
           </Paper>
         ))}
       </List>

--- a/src/stores/uploadStore.ts
+++ b/src/stores/uploadStore.ts
@@ -11,7 +11,8 @@ export interface FileUploadStatus {
   progress?: number;
   error?: string;
   info?: DataTableInfo;
-  timeoutId?: ReturnType<typeof setTimeout>; // 用於儲存定時器 ID
+  timeoutId?: ReturnType<typeof setTimeout>;
+  isExpanded?: boolean;
 }
 
 interface UploadState {
@@ -26,7 +27,8 @@ interface UploadState {
   // 處理上傳檔案的非同步邏輯
   startUploads: (files: File[]) => Promise<void>;
   reset: () => void;
-  removeUpload: (id: string) => void; // 新增移除方法
+  removeUpload: (id: string) => void;
+  toggleExpand: (id: string) => void;
 }
 
 export const useUploadStore = create<UploadState>()(
@@ -35,11 +37,18 @@ export const useUploadStore = create<UploadState>()(
       uploads: [],
 
       addUpload: (file: File) => {
-        const newId = `${file.name}-${Date.now()}-${Math.random().toString(36).substr(2, 9)}`;
+        const newId = `${file.name}-${Date.now()}-${Math.random()
+          .toString(36)
+          .substring(2, 9)}`;
         set((state) => ({
           uploads: [
             ...state.uploads,
-            { id: newId, fileName: file.name, status: "uploading" },
+            {
+              id: newId,
+              fileName: file.name,
+              status: "uploading",
+              isExpanded: false,
+            }, // 初始化為收合狀態
           ],
         }));
         return newId;
@@ -48,7 +57,9 @@ export const useUploadStore = create<UploadState>()(
       updateUploadStatus: (id, status, info, error) => {
         set((state) => ({
           uploads: state.uploads.map((upload) =>
-            upload.id === id ? { ...upload, status, info, error } : upload
+            upload.id === id
+              ? { ...upload, status, info, error, isExpanded: false }
+              : upload
           ),
         }));
       },
@@ -56,6 +67,16 @@ export const useUploadStore = create<UploadState>()(
       removeUpload: (id) => {
         set((state) => ({
           uploads: state.uploads.filter((upload) => upload.id !== id),
+        }));
+      },
+
+      toggleExpand: (id) => {
+        set((state) => ({
+          uploads: state.uploads.map((upload) =>
+            upload.id === id
+              ? { ...upload, isExpanded: !upload.isExpanded }
+              : upload
+          ),
         }));
       },
 
@@ -81,7 +102,7 @@ export const useUploadStore = create<UploadState>()(
             // 成功後設定定時器
             setTimeout(() => {
               removeUpload(newId);
-            }, 10000); // 10 秒後自動移除
+            }, 10000);
           } catch (e: unknown) {
             console.error(`上傳 ${file.name} 失敗:`, e);
             const errorMsg = e instanceof Error ? e.message : "未知錯誤";
@@ -90,7 +111,7 @@ export const useUploadStore = create<UploadState>()(
             // 失敗後設定定時器
             setTimeout(() => {
               removeUpload(newId);
-            }, 30000); // 30 秒後自動移除
+            }, 30000);
           }
         }
       },


### PR DESCRIPTION
feat(upload): Enhance upload status panel with expandable details

# ✨ Feature PR

## 📌 Feature Summary
This PR enhances the upload status panel by introducing expandable details for each upload entry. The changes replace a simple list with an accordion, allowing users to expand or collapse each upload item to view additional details.

- **Feature Name**: Enhance upload status panel
- **Description**: Replace `ListItem` with an `Accordion` to allow expanding/collapsing upload entries. Show detailed error messages for failed uploads. Add an empty state message for clearer feedback.

## 🔗 Related Issues / PR
- Closes #40

## 🛠 Changes
- [x] **New**: Added an **`isExpanded`** flag and **`toggleExpand`** action to the `uploadStore` to control the UI state.
- [x] **Modification**: Replaced `ListItem` with `Accordion` in `UploadStatusPanel.tsx` to enable expandable details.
- [x] **Modification**: Updated the `updateUploadStatus` action to reset the expansion state on status updates.
- [x] **Modification**: Added error details for failed uploads.
- [x] **Modification**: Added an empty state message for when the upload list is empty.

## ✅ Test Items
- [ ] Verify that clicking an upload item expands it to show details.
- [ ] Confirm that clicking the delete button for a failed or successful upload removes the item without expanding/collapsing the accordion.
- [ ] Test the empty state message to ensure it appears correctly when there are no uploads.
- [ ] Ensure error details are displayed correctly for failed uploads.

## ⚠ Potential Impacts / Risks
- [ ] This change impacts the UI of the upload status panel.
- [ ] The `uploadStore` now manages an additional state (`isExpanded`), which may require careful consideration if future UI components rely on this store.

## 📸 Screenshots / Videos

### Before Change
<img width="316" height="584" alt="Image" src="https://github.com/user-attachments/assets/d763c542-f6bd-4552-8578-b39917a14b83" />

### After Change

Before Expand
<img width="307" height="442" alt="image" src="https://github.com/user-attachments/assets/af68b93e-2cdf-4a91-b833-34ec0f871d9b" />


After Expand
<img width="337" height="942" alt="image" src="https://github.com/user-attachments/assets/cfd40a3d-133d-43fa-b2b2-b59554d150eb" />

---

feat(upload): 強化上傳狀態面板，支援展開細節

# ✨ 功能 PR

## 📌 功能簡介
此 PR 強化了上傳狀態面板，為每個上傳項目新增展開/收合細節功能。主要變更為將簡單的清單替換為可摺疊的 **Accordion** 元件，讓使用者可以展開或收合每個上傳項目，以查看額外的詳細資訊。

- **功能名稱**：強化上傳狀態面板
- **功能說明**：使用 `Accordion` 取代 `ListItem`，支援展開/收合上傳項目。失敗時顯示詳細的錯誤原因。新增空清單提示訊息以提供更清晰的回饋。

## 🔗 關聯 Issue / PR
- Closes #40

## 🛠 變更內容
- [x] **新增**：在 `uploadStore` 中加入 `isExpanded` 狀態與 `toggleExpand` 方法，控制 UI 展開/收合。
- [x] **修改**：在 `UploadStatusPanel.tsx` 中使用 `Accordion` 取代 `ListItem`，以實現可展開的細節功能。
- [x] **修改**：在狀態更新時，重設展開狀態。
- [x] **修改**：上傳失敗時，顯示詳細的錯誤原因。
- [x] **修改**：新增空清單提示訊息。

## ✅ 測試項目
- [ ] 驗證點擊上傳項目時，可正確展開並顯示細節。
- [ ] 確認點擊失敗或成功上傳項目旁的刪除按鈕時，項目會被移除且不會觸發 Accordion 的展開/收合。
- [ ] 驗證當上傳清單為空時，空清單提示訊息是否正確顯示。
- [ ] 確認失敗上傳的錯誤資訊顯示正確。

## ⚠ 可能的影響範圍 / 風險
- [ ] 此變更影響上傳狀態面板的 UI。
- [ ] `uploadStore` 現在多了一個狀態 (`isExpanded`)，若未來其他 UI 元件依賴此 store，需謹慎處理。

## 📸 截圖 / 錄影

### 變更前
<img width="316" height="584" alt="Image" src="https://github.com/user-attachments/assets/d763c542-f6bd-4552-8578-b39917a14b83" />

### 變更後

展開前
<img width="307" height="442" alt="image" src="https://github.com/user-attachments/assets/af68b93e-2cdf-4a91-b833-34ec0f871d9b" />


展開後
<img width="337" height="942" alt="image" src="https://github.com/user-attachments/assets/cfd40a3d-133d-43fa-b2b2-b59554d150eb" />

