### PR TITLE
hotfix(chore): refine type check and update uploadTable signature

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,13 +3,10 @@ name: CI
 on:
   push:
     branches:
-      - main
-      - dev
-      - "feat/**"
+      - '**'  # 任何分支都會觸發
   pull_request:
     branches:
-      - main
-      - dev
+      - '**'  # 所有目標分支的 PR 都會觸發
 
 jobs:
   build-and-check:
@@ -29,11 +26,9 @@ jobs:
 
       - name: Run Lint
         run: npm run lint
-        continue-on-error: ${{ github.ref != 'refs/heads/main' }} # feat/dev 允許警告
 
       - name: Type Check
         run: npm run type-check
-        continue-on-error: ${{ github.ref != 'refs/heads/main' }}
 
       - name: Run Tests
         run: npm test -- --coverage
@@ -42,3 +37,12 @@ jobs:
       - name: Run Security Audit
         run: npm audit --audit-level=moderate
         continue-on-error: false
+
+      # 額外提示：如果是在 main 分支，顯示「嚴格模式」
+      - name: Summary
+        run: |
+          if [ "${GITHUB_REF}" = "refs/heads/main" ]; then
+            echo "✅ Strict mode: all checks required to pass."
+          else
+            echo "⚠️  Non-main branch: tests or audit may fail without blocking CI."
+          fi

--- a/package-lock.json
+++ b/package-lock.json
@@ -4993,6 +4993,7 @@
       "integrity": "sha512-59CAAjAhTaIMCN8y9kD573vDkxbs1uhDcrFLHSgutYdPcGOU35Rf95725snvzEOy4BFB7+eLJ8djCNPmGwG67w==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "app-builder-lib": "26.0.12",
         "builder-util": "26.0.11",
@@ -11595,21 +11596,6 @@
       "integrity": "sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g==",
       "dev": true,
       "license": "ISC"
-    },
-    "node_modules/yaml": {
-      "version": "2.8.1",
-      "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.8.1.tgz",
-      "integrity": "sha512-lcYcMxX2PO9XMGvAJkJ3OsNMw+/7FKes7/hgerGUYWIoWu5j/+YQqcZr5JnPZWzOsEBgMbSbiSTn/dv/69Mkpw==",
-      "dev": true,
-      "license": "ISC",
-      "optional": true,
-      "peer": true,
-      "bin": {
-        "yaml": "bin.mjs"
-      },
-      "engines": {
-        "node": ">= 14.6"
-      }
     },
     "node_modules/yargs": {
       "version": "17.7.2",

--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
     "dev:react": "vite",
     "dev:electron": "npm run transpile:electron && cross-env NODE_ENV=development electron .",
     "build": "tsc -b && vite build",
-    "type-check": "tsc --noEmit",
+    "type-check": "tsc -b --noEmit",
     "format": "prettier --write .",
     "lint": "eslint .",
     "preview": "vite preview",

--- a/src/pages/DataTableEditorPage.tsx
+++ b/src/pages/DataTableEditorPage.tsx
@@ -54,7 +54,7 @@ export const DataTableEditorPage: React.FC = () => {
       } else {
         console.log(`確認並儲存表格: ${tableName}`);
         const tableInfo = { name: tableName, description: "" };
-        await window.api.uploadTable(tableInfo, data);
+        await window.api.uploadTable(tableInfo, data, "create");
         console.log("儲存成功!");
       }
       navigate("/data-tables");

--- a/src/preload.d.ts
+++ b/src/preload.d.ts
@@ -7,7 +7,7 @@ import type {
   DataTableWithInfo,
   UploadInputDataTableInfo,
 } from "shared/types/dataTable";
-import type { Message, ConflictResult } from "shared/types";
+import type { Message, ConflictResult, UploadMode } from "shared/types";
 import type { ChartInfo } from "shared/types/chart";
 interface DataTableAPI {
   uploadTable: (


### PR DESCRIPTION
chore: refine type check and update uploadTable signature

- Use tsc -b --noEmit for stricter project-wide type checking
- Explicitly pass "create" mode in uploadTable call
- Add UploadMode import in preload.d.ts
- Update ci.yml

---

chore: 強化型別檢查與更新 uploadTable 呼叫方式

- type-check 指令改為使用 tsc -b --noEmit
- 上傳表格時明確指定 "create" 模式
- preload.d.ts 補上 UploadMode 型別匯入
- 更新 ci.yml