### PR TITLE
**refactor: modularize upload status components and unify error constants** （重構：模組化上傳狀態組件並統一錯誤常數）

### DIFF
--- a/docs/專案提示詞紀錄/專案提示詞紀錄-14.md
+++ b/docs/專案提示詞紀錄/專案提示詞紀錄-14.md
@@ -1,0 +1,2341 @@
+## Copilot 提問 建立儀表板列表頁（列表/卡片檢視）
+> 另開新一頁
+
+你是一名專業的全端桌面軟體程式設計師，有多年使用 Electron + better-sqlite3 + Vite + React 的豐富經驗，現在面對以下專案和問題
+
+### 🧩 專案背景：
+- 使用技術：
+  - 前端 Vite + React + MUI + Zustand + TypeScript
+  - 後端 Electron + better-sqlite3
+- 專案類型：資料視覺化儀表板
+- 目前架構：
+```front end
+  src/
+  ├── assets/data.json, snake.jpg
+  ├── components/common/ConfirmCancelButtons.tsx, DataTable.tsx, DeleteWarningDialog.tsx, EditableCell.tsx, EditableTitle.tsx, Logo.tsx, PageHeader.tsx, SimpleTable.tsx
+  ├── components/DataTablesPage/DataTableList.tsx, UploadDataTableDialog.tsx, UploadStatusPanel.tsx
+  ├── components/layout/Breadcrumb.tsx, layout.css, Layout.tsx, PageWrapper.tsx, RightPanel.tsx, Sidebar.tsx, TocList.tsx, TocListItem.tsx, TopNav.tsx
+  ├── context/LayoutContext.tsx, LayoutProvider.tsx, useLayoutContext.tsx
+  ├── hooks/useFileParser.tsx, useTableDataInitializer.tsx, useTableEditor.tsx, useTableGetter.tsx
+  ├── pages/DataTableEditorPage.tsx, DataTablesPage.tsx, HomePage.tsx
+  ├── stores/layoutStore.ts, uploadStore.ts
+  ├── theme/index.ts
+  ├── App.tsx
+  ├── constants.ts
+  ├── main.tsx
+  ├── mui.d.ts
+  ├── preload.d.ts
+  ├── types.tsx
+  ├── utils.tsx
+  └── vite-env.d.ts
+```
+```backend
+  electron/
+  ├── ipc/APIModule.cts, ChartAPIHandlers.cts, DashboardAPIHandlers.cts, DataTableAPIHandlers.cts
+  ├── models/ChartManager.cts, DatabaseManager.cts, DataTableManager.cts, FileManager.cts
+  ├── node_modules/.tmp/tsconfig.electron.tsbuildinfo
+  ├── services/DataTableService.cts
+  ├── windows/mainWindow.cts
+  ├── constants.cts
+  ├── main.cts
+  ├── preload.cts
+  ├── tsconfig.json
+  ├── types.cts
+  └── utils.cts
+```
+
+### 🧱 已完成項目：
+- ipc: 綁定 DataTable 資料表相關 API
+- 使用 PageWrapper 完成排版相關的包裝
+- DataTable 相關增刪修(前後端)皆已完成
+
+### 🔧 目前狀態：
+建立可配置的儀表板模組，支援圖表建立、儲存、展示，完成前端與後端 IPC 整合。
+
+### ❓接下來想處理的問題：
+我們先聚焦於 UI 部分，也就是建立儀表板列表頁（列表/卡片檢視）: 我們需要管理多個儀表板，列表頁羅列所有儀表板項目，並提供列表/卡片兩種檢視方法，點擊其中任一儀表板項目名稱會連結到儀表板展示頁。
+
+請參考以下類似代碼:
+
+```tsx
+// src/pages/DataTablesPage.tsx
+import { useEffect, useState } from "react";
+import { useNavigate } from "react-router-dom";
+import {
+  Box,
+  Typography,
+  TextField,
+  Button,
+  Grid,
+  ToggleButtonGroup,
+  ToggleButton,
+} from "@mui/material";
+import FormatListBulletedIcon from "@mui/icons-material/FormatListBulleted";
+import AddIcon from "@mui/icons-material/Add";
+import UploadIcon from "@mui/icons-material/Upload";
+import GridViewIcon from "@mui/icons-material/GridView";
+import { PageWrapper } from "../components/layout/PageWrapper";
+import { DataTableList } from "../components/DataTablesPage/DataTableList";
+import { UploadDataTableDialog } from "../components/DataTablesPage/UploadDataTableDialog";
+import { useUploadStore } from "../stores/uploadStore";
+import type { DataTableInfo } from "shared/types/dataTable";
+import type { CreateTableNavigateState, PageConfig } from "../types";
+import { UploadStatusPanel } from "../components/DataTablesPage/UploadStatusPanel"; // 新增元件
+
+export const DataTablesPage = () => {
+  const [searchText, setSearchText] = useState("");
+  const [uploadDialogOpen, setUploadDialogOpen] = useState(false);
+  const [viewMode, setViewMode] = useState<"card" | "list">("card");
+  const [tableInfos, setTableInfos] = useState<DataTableInfo[]>([]);
+  const navigate = useNavigate();
+
+  // 從 Zustand Store 獲取上傳狀態
+  const uploads = useUploadStore((state) => state.uploads);
+  const resetUploads = useUploadStore((state) => state.reset);
+
+  // 監聽 uploads 狀態的變化，並在有成功上傳時刷新列表
+  useEffect(() => {
+    console.log("Uploads state changed:", uploads);
+    if (uploads.some((u) => u.status === "success")) {
+      console.log("Detected successful upload, refreshing table infos...");
+      refreshTableInfos();
+    }
+  }, [uploads]);
+
+  useEffect(() => {
+    refreshTableInfos();
+    // 頁面初次載入時清空上傳狀態，避免上次的紀錄影響本次
+    return () => {
+      resetUploads();
+    };
+  }, [resetUploads]);
+
+  const refreshTableInfos = () => {
+    window.api.getAllTableInfos().then((tables) => {
+      setTableInfos(tables);
+    });
+  };
+
+  // 根據搜尋關鍵字過濾資料
+  const filteredDataTables = tableInfos.filter((table) =>
+    table.name.toLowerCase().includes(searchText.toLowerCase())
+  );
+
+  const handleViewModeChange = (
+    _event: React.MouseEvent<HTMLElement>,
+    newViewMode: "card" | "list"
+  ) => {
+    if (newViewMode !== null) {
+      setViewMode(newViewMode);
+    }
+  };
+
+  const handleNewTableClick = () => {
+    const state: CreateTableNavigateState = { editorMode: "create" };
+    navigate("/data-tables/edit", { state });
+  };
+
+  // 頁面配置
+  const pageConfig: Omit<PageConfig, "tocItems"> = {
+    breadcrumbItems: [{ label: "資料表格管理", path: "/data-tables" }],
+    content: (
+      <Box sx={{ p: 3 }}>
+        <Grid container alignItems="center" spacing={2} sx={{ mb: 3 }}>
+          <Grid
+            size={{ xs: 12, sm: 6 }}
+            container
+            alignItems="center"
+            spacing={2}
+          >
+            {/* 標題與模式切換按鈕 */}
+            <Grid>
+              <Typography variant="h4" sx={{ fontWeight: "bold" }}>
+                資料表格管理
+              </Typography>
+            </Grid>
+            <Grid>
+              <ToggleButtonGroup
+                value={viewMode}
+                exclusive
+                onChange={handleViewModeChange}
+                aria-label="view mode"
+                size="small"
+              >
+                <ToggleButton value="card" aria-label="card view">
+                  <GridViewIcon />
+                </ToggleButton>
+                <ToggleButton value="list" aria-label="list view">
+                  <FormatListBulletedIcon />
+                </ToggleButton>
+              </ToggleButtonGroup>
+            </Grid>
+          </Grid>
+          <Grid
+            size={{ xs: 12, sm: 6 }}
+            container
+            justifyContent="flex-end"
+            spacing={1}
+          >
+            {/* 搜尋框 */}
+            <Grid>
+              <TextField
+                label="搜尋表格"
+                variant="outlined"
+                size="small"
+                value={searchText}
+                onChange={(e) => setSearchText(e.target.value)}
+              />
+            </Grid>
+            {/* 新增表格按鈕 */}
+            <Grid>
+              <Button
+                variant="contained"
+                startIcon={<AddIcon />}
+                onClick={() => handleNewTableClick()}
+              >
+                新增資料表格
+              </Button>
+            </Grid>
+            {/* 上傳按鈕 */}
+            <Grid>
+              <Button
+                variant="contained"
+                startIcon={<UploadIcon />}
+                onClick={() => setUploadDialogOpen(true)}
+              >
+                上傳資料表格
+              </Button>
+            </Grid>
+          </Grid>
+        </Grid>
+
+        {/* 資料表格列表 */}
+        <DataTableList
+          dataTables={filteredDataTables}
+          viewMode={viewMode}
+          refreshTableInfos={refreshTableInfos}
+        />
+
+        {/* 上傳資料表格對話框 */}
+        <UploadDataTableDialog
+          open={uploadDialogOpen}
+          onClose={() => setUploadDialogOpen(false)}
+        />
+      </Box>
+    ),
+    rightPanelContent: <UploadStatusPanel />, // 這裡使用新元件
+    rightPanelTitle: "上傳狀態",
+  };
+
+  return <PageWrapper {...pageConfig} />;
+};
+```
+
+```tsx
+export const DataTableList = ({
+  dataTables,
+  viewMode,
+  refreshTableInfos,
+}: Props) => {
+  const [anchorEl, setAnchorEl] = useState<null | HTMLElement>(null);
+  const [selectedTableId, setSelectedTableId] = useState<TableId | null>(null);
+  const [openDialog, setOpenDialog] = useState(false);
+  const navigate = useNavigate();
+
+  const handleTableClick = (
+    _event: React.MouseEvent<HTMLElement>,
+    tableId: TableId
+  ) => {
+    console.log(`點擊了表格 ${tableId}`);
+    const state: EditTableNavigateState = {
+      editorMode: "edit",
+      tableId: tableId,
+    };
+    navigate("/data-tables/edit", {
+      state,
+    });
+  };
+
+  const handleMenuClick = (
+    event: React.MouseEvent<HTMLElement>,
+    tableId: TableId
+  ) => {
+    setAnchorEl(event.currentTarget);
+    setSelectedTableId(tableId);
+  };
+
+  const handleMenuClose = () => {
+    setAnchorEl(null);
+    setSelectedTableId(null);
+  };
+
+  const handleAction = (action: string) => {
+    console.log(`對表格 ${selectedTableId} 執行操作: ${action}`);
+    handleMenuClose();
+  };
+
+  const closeDeleteDialog = () => {
+    setOpenDialog(false);
+    handleMenuClose();
+  };
+  const openDeleteDialog = () => {
+    setOpenDialog(true);
+    setAnchorEl(null);
+  };
+  const handleConfirmDelete = () => {
+    console.log(`刪除表格 ${selectedTableId}`);
+    window.api.deleteTable(selectedTableId!);
+    setOpenDialog(false);
+    handleMenuClose();
+    refreshTableInfos();
+  };
+
+  // 渲染列表的 Helper 函式
+  const renderList = () => (
+    <TableContainer component={Paper}>
+      <Table>
+        <TableHead>
+          <TableRow>
+            <TableCell>表格名稱</TableCell>
+            <TableCell>上傳日期</TableCell>
+            <TableCell>檔案大小</TableCell>
+            <TableCell align="right">操作</TableCell>
+          </TableRow>
+        </TableHead>
+        <TableBody>
+          {dataTables.map((table) => (
+            <TableRow key={table.id}>
+              <TableCell>
+                <Link onClick={(e) => handleTableClick(e, table.id)}>
+                  {table.name}
+                </Link>
+              </TableCell>
+              <TableCell>{table.updated_at}</TableCell>
+              <TableCell>{table.fileSize}</TableCell>
+              <TableCell align="right">
+                <IconButton
+                  aria-label="more"
+                  onClick={(e) => handleMenuClick(e, table.id)}
+                >
+                  <MoreVertIcon />
+                </IconButton>
+              </TableCell>
+            </TableRow>
+          ))}
+        </TableBody>
+      </Table>
+    </TableContainer>
+  );
+
+  // 渲染卡片的 Helper 函式
+  const renderCards = () => (
+    <Grid container spacing={3}>
+      {dataTables.length > 0 ? (
+        dataTables.map((table) => (
+          <Grid size={{ xs: 12, sm: 6, md: 4 }} key={table.id}>
+            <Card variant="outlined">
+              <CardContent>
+                <Box
+                  sx={{
+                    display: "flex",
+                    justifyContent: "space-between",
+                    alignItems: "center",
+                  }}
+                >
+                  <Typography variant="h6" component="div">
+                    <Link onClick={(e) => handleTableClick(e, table.id)}>
+                      {table.name}
+                    </Link>
+                  </Typography>
+                  <IconButton
+                    aria-label="more"
+                    onClick={(e) => handleMenuClick(e, table.id)}
+                  >
+                    <MoreVertIcon />
+                  </IconButton>
+                </Box>
+                <Typography variant="body2" color="text.secondary">
+                  上傳日期: {table.updated_at}
+                </Typography>
+                <Typography variant="body2" color="text.secondary">
+                  檔案大小: {table.fileSize}
+                </Typography>
+              </CardContent>
+            </Card>
+          </Grid>
+        ))
+      ) : (
+        <Grid size={{ xs: 12 }}>
+          <Typography variant="h6" color="text.secondary" align="center">
+            沒有找到符合條件的資料表格。
+          </Typography>
+        </Grid>
+      )}
+    </Grid>
+  );
+
+  return (
+    <Box>
+      {dataTables.length === 0 ? (
+        <Typography variant="h6" color="text.secondary" align="center">
+          沒有找到符合條件的資料表格。
+        </Typography>
+      ) : (
+        <>{viewMode === "card" ? renderCards() : renderList()}</>
+      )}
+      {/* 單一表格操作選單 (保持不變) */}
+      <Menu
+        anchorEl={anchorEl}
+        open={Boolean(anchorEl)}
+        onClose={handleMenuClose}
+      >
+        <MenuItem onClick={() => handleAction("更新")}>更新</MenuItem>
+        <MenuItem onClick={() => handleAction("下載")}>下載</MenuItem>
+        <MenuItem onClick={() => openDeleteDialog()}>刪除</MenuItem>
+      </Menu>
+      <DeleteWarningDialog
+        title="刪除資料表格"
+        content="確定要刪除這個資料表格嗎？此操作無法復原。"
+        open={openDialog}
+        handleClose={closeDeleteDialog}
+        handleComfirm={handleConfirmDelete}
+      />
+    </Box>
+  );
+};
+```
+
+## Copilot 回答 建立儀表板列表頁（列表/卡片檢視）
+非常棒的專案架構與說明！你已經建立了清晰的資料表格管理頁面，現在要擴充成「儀表板列表頁」並支援「列表 / 卡片檢視」的 UI，其實可以沿用你現有的 `DataTablesPage` 和 `DataTableList` 的設計模式。
+
+以下是我建議的實作步驟與元件拆分方式：
+
+---
+
+### ✅ 建議元件結構
+
+你可以建立以下新元件：
+
+```
+src/
+├── pages/DashboardsPage.tsx
+├── components/DashboardsPage/
+│   ├── DashboardList.tsx
+│   ├── DashboardCard.tsx
+│   ├── DashboardListItem.tsx
+│   └── UploadDashboardDialog.tsx (如果有上傳功能)
+```
+
+---
+
+### 🧱 DashboardsPage.tsx（儀表板列表頁）
+
+這個頁面可以參考 `DataTablesPage.tsx` 的結構，包含：
+
+- 搜尋框
+- 切換檢視模式（卡片 / 列表）
+- 新增儀表板按鈕
+- 儀表板列表元件（`DashboardList`）
+
+```tsx
+export const DashboardsPage = () => {
+  const [searchText, setSearchText] = useState("");
+  const [viewMode, setViewMode] = useState<"card" | "list">("card");
+  const [dashboards, setDashboards] = useState<DashboardInfo[]>([]);
+  const navigate = useNavigate();
+
+  useEffect(() => {
+    window.api.getAllDashboards().then(setDashboards);
+  }, []);
+
+  const filteredDashboards = dashboards.filter((d) =>
+    d.name.toLowerCase().includes(searchText.toLowerCase())
+  );
+
+  const handleViewModeChange = (_: any, mode: "card" | "list") => {
+    if (mode) setViewMode(mode);
+  };
+
+  const handleNewDashboardClick = () => {
+    navigate("/dashboards/create");
+  };
+
+  const pageConfig: Omit<PageConfig, "tocItems"> = {
+    breadcrumbItems: [{ label: "儀表板管理", path: "/dashboards" }],
+    content: (
+      <Box sx={{ p: 3 }}>
+        {/* 標題與操作列 */}
+        <Grid container justifyContent="space-between" alignItems="center" sx={{ mb: 3 }}>
+          <Grid item>
+            <Typography variant="h4" fontWeight="bold">儀表板管理</Typography>
+          </Grid>
+          <Grid item>
+            <ToggleButtonGroup value={viewMode} exclusive onChange={handleViewModeChange}>
+              <ToggleButton value="card"><GridViewIcon /></ToggleButton>
+              <ToggleButton value="list"><FormatListBulletedIcon /></ToggleButton>
+            </ToggleButtonGroup>
+          </Grid>
+        </Grid>
+
+        {/* 搜尋與新增 */}
+        <Grid container spacing={2} sx={{ mb: 2 }}>
+          <Grid item xs={12} sm={6}>
+            <TextField
+              label="搜尋儀表板"
+              fullWidth
+              value={searchText}
+              onChange={(e) => setSearchText(e.target.value)}
+            />
+          </Grid>
+          <Grid item xs={12} sm={6} textAlign="right">
+            <Button variant="contained" startIcon={<AddIcon />} onClick={handleNewDashboardClick}>
+              新增儀表板
+            </Button>
+          </Grid>
+        </Grid>
+
+        {/* 儀表板列表 */}
+        <DashboardList dashboards={filteredDashboards} viewMode={viewMode} />
+      </Box>
+    ),
+  };
+
+  return <PageWrapper {...pageConfig} />;
+};
+```
+
+---
+
+### 🧩 DashboardList.tsx
+
+這個元件根據 `viewMode` 顯示卡片或列表：
+
+```tsx
+export const DashboardList = ({
+  dashboards,
+  viewMode,
+}: {
+  dashboards: DashboardInfo[];
+  viewMode: "card" | "list";
+}) => {
+  const navigate = useNavigate();
+
+  const handleClick = (id: string) => {
+    navigate(`/dashboards/view/${id}`);
+  };
+
+  return (
+    <Box>
+      {viewMode === "card" ? (
+        <Grid container spacing={3}>
+          {dashboards.map((d) => (
+            <Grid item xs={12} sm={6} md={4} key={d.id}>
+              <DashboardCard dashboard={d} onClick={() => handleClick(d.id)} />
+            </Grid>
+          ))}
+        </Grid>
+      ) : (
+        <List>
+          {dashboards.map((d) => (
+            <DashboardListItem key={d.id} dashboard={d} onClick={() => handleClick(d.id)} />
+          ))}
+        </List>
+      )}
+    </Box>
+  );
+};
+```
+
+---
+
+### 🧩 DashboardCard.tsx / DashboardListItem.tsx
+
+這兩個元件分別負責卡片與列表的 UI 呈現，結構可參考你現有的 `DataTableList` 中的 `renderCards` / `renderList`。
+
+---
+
+### 📦 IPC API 建議
+
+後端 `electron/ipc/DashboardAPIHandlers.cts` 可新增：
+
+```ts
+ipcMain.handle("getAllDashboards", () => {
+  return DashboardManager.getAll(); // 回傳 dashboard 資訊陣列
+});
+```
+
+前端 preload：
+
+```ts
+contextBridge.exposeInMainWorld("api", {
+  getAllDashboards: () => ipcRenderer.invoke("getAllDashboards"),
+});
+```
+
+---
+
+如果你希望我幫你產出 `DashboardCard.tsx` 或 `DashboardListItem.tsx` 的具體程式碼，我可以直接幫你寫好。你也可以告訴我儀表板的資料結構（例如 `DashboardInfo` 型別），我會更精準地幫你設計 UI。
+
+是否需要我幫你補齊這些元件呢？或者你有特定的 UI 想像？
+
+## Copilot 提問 列表代碼抽象化
+列表代碼可能要用於 儀錶板、圖表、用戶等，請問能抽象一般化嗎，還是說不要更好，請分析優劣
+
+## Copilot 回答 列表代碼抽象化
+這是一個非常好的問題，針對你目前的 `DataTableList` 元件是否要抽象化為通用的「列表/卡片檢視元件」，我來幫你分析優劣：
+
+---
+
+### ✅ 抽象化的優點
+
+1. **程式碼重用性高**  
+   儀表板、圖表、用戶等模組都可能需要類似的列表/卡片檢視邏輯，抽象化後可共用 UI 結構與互動邏輯。
+
+2. **維護成本降低**  
+   UI 改動（例如樣式、操作選單）只需修改一次，所有使用的地方都會同步更新。
+
+3. **一致性設計**  
+   使用者在不同模組中看到的列表/卡片呈現方式一致，提升使用體驗。
+
+4. **可擴充性強**  
+   可以透過 props 傳入不同的資料結構與操作邏輯，支援多種資料類型。
+
+---
+
+### ❌ 抽象化的缺點
+
+1. **抽象成本高**  
+   初期需要花時間設計通用型元件的 API（例如：資料欄位、操作項目、點擊事件等），可能會讓開發變慢。
+
+2. **彈性可能受限**  
+   若不同模組的 UI 差異大（例如：儀表板有圖表預覽、用戶有頭像與角色標籤），通用元件可能需要大量客製化 props 或 slot，反而變得複雜。
+
+3. **型別泛化困難**  
+   TypeScript 中要處理多種資料型別（如 `DataTableInfo`、`DashboardInfo`、`UserInfo`）可能需要泛型與 discriminated union，增加學習與維護門檻。
+
+---
+
+### 🧠 建議策略：半抽象化（推薦）
+
+你可以採用「半抽象化」策略：
+
+#### ✅ 抽象出以下部分：
+
+- `GenericListView`：通用的列表呈現元件
+- `GenericCardView`：通用的卡片呈現元件
+- `ItemActionsMenu`：通用的操作選單元件（更新、刪除、下載等）
+
+#### ✅ 保留以下部分為模組專用：
+
+- 點擊事件邏輯（navigate 到哪裡）
+- 資料欄位格式化（例如：檔案大小、日期格式）
+- 刪除確認對話框內容
+
+---
+
+### 🧱 範例：抽象化元件 API 設計
+
+```tsx
+interface GenericItem {
+  id: string;
+  title: string;
+  subtitle?: string;
+  metadata?: Record<string, string>;
+}
+
+interface GenericListProps {
+  items: GenericItem[];
+  viewMode: "list" | "card";
+  onClickItem: (id: string) => void;
+  onAction: (action: string, id: string) => void;
+}
+```
+
+這樣你就可以在 `DataTableList`、`DashboardList`、`UserList` 中傳入不同的 `items` 與 `onClickItem`，但共用 UI 呈現元件。
+
+---
+
+如果你希望我幫你開始抽象化這個元件，我可以幫你先寫出 `GenericListView` 的初版，並示範如何在 `DataTableList` 中使用它。你想要我幫你開始嗎？還是你想先針對某個模組試試看？
+
+## Copilot 提問 列表代碼抽象化-半抽象化與使用範例
+幫我寫一個 GenericListView 範例 + 示範如何在 DataTableList 中使用它
+
+## Copilot 回答 列表代碼抽象化-半抽象化與使用範例
+當然可以！以下是你要的抽象元件 `GenericListView`，以及如何在 `DataTableList` 中使用它的示範。
+
+---
+
+### ✅ 1. 建立 `GenericListView.tsx`
+
+```tsx
+// src/components/common/GenericListView.tsx
+import {
+  Box,
+  Card,
+  CardContent,
+  Typography,
+  Grid,
+  Table,
+  TableBody,
+  TableCell,
+  TableContainer,
+  TableHead,
+  TableRow,
+  Paper,
+  IconButton,
+  Link,
+} from "@mui/material";
+import MoreVertIcon from "@mui/icons-material/MoreVert";
+
+export interface GenericItem {
+  id: string;
+  title: string;
+  subtitle?: string;
+  metadata?: Record<string, string>;
+}
+
+export interface GenericListViewProps {
+  items: GenericItem[];
+  viewMode: "card" | "list";
+  onClickItem: (id: string) => void;
+  onMenuClick?: (event: React.MouseEvent<HTMLElement>, id: string) => void;
+}
+
+export const GenericListView = ({
+  items,
+  viewMode,
+  onClickItem,
+  onMenuClick,
+}: GenericListViewProps) => {
+  const renderList = () => (
+    <TableContainer component={Paper}>
+      <Table>
+        <TableHead>
+          <TableRow>
+            <TableCell>名稱</TableCell>
+            <TableCell>副標題</TableCell>
+            <TableCell>其他資訊</TableCell>
+            <TableCell align="right">操作</TableCell>
+          </TableRow>
+        </TableHead>
+        <TableBody>
+          {items.map((item) => (
+            <TableRow key={item.id}>
+              <TableCell>
+                <Link onClick={() => onClickItem(item.id)}>{item.title}</Link>
+              </TableCell>
+              <TableCell>{item.subtitle}</TableCell>
+              <TableCell>
+                {item.metadata &&
+                  Object.entries(item.metadata)
+                    .map(([k, v]) => `${k}: ${v}`)
+                    .join(" / ")}
+              </TableCell>
+              <TableCell align="right">
+                {onMenuClick && (
+                  <IconButton onClick={(e) => onMenuClick(e, item.id)}>
+                    <MoreVertIcon />
+                  </IconButton>
+                )}
+              </TableCell>
+            </TableRow>
+          ))}
+        </TableBody>
+      </Table>
+    </TableContainer>
+  );
+
+  const renderCards = () => (
+    <Grid container spacing={3}>
+      {items.map((item) => (
+        <Grid item xs={12} sm={6} md={4} key={item.id}>
+          <Card variant="outlined">
+            <CardContent>
+              <Box
+                sx={{
+                  display: "flex",
+                  justifyContent: "space-between",
+                  alignItems: "center",
+                }}
+              >
+                <Typography variant="h6">
+                  <Link onClick={() => onClickItem(item.id)}>{item.title}</Link>
+                </Typography>
+                {onMenuClick && (
+                  <IconButton onClick={(e) => onMenuClick(e, item.id)}>
+                    <MoreVertIcon />
+                  </IconButton>
+                )}
+              </Box>
+              <Typography variant="body2" color="text.secondary">
+                {item.subtitle}
+              </Typography>
+              {item.metadata &&
+                Object.entries(item.metadata).map(([k, v]) => (
+                  <Typography key={k} variant="body2" color="text.secondary">
+                    {k}: {v}
+                  </Typography>
+                ))}
+            </CardContent>
+          </Card>
+        </Grid>
+      ))}
+    </Grid>
+  );
+
+  return <Box>{viewMode === "card" ? renderCards() : renderList()}</Box>;
+};
+```
+
+---
+
+### ✅ 2. 在 `DataTableList.tsx` 中使用
+
+你只需要將 `DataTableInfo[]` 轉換成 `GenericItem[]`，然後使用 `GenericListView`：
+
+```tsx
+import { GenericListView, GenericItem } from "../common/GenericListView";
+
+// 將 DataTableInfo 轉換成 GenericItem
+const genericItems: GenericItem[] = dataTables.map((table) => ({
+  id: table.id,
+  title: table.name,
+  subtitle: table.updated_at,
+  metadata: {
+    檔案大小: table.fileSize,
+  },
+}));
+
+return (
+  <Box>
+    <GenericListView
+      items={genericItems}
+      viewMode={viewMode}
+      onClickItem={(id) => handleTableClick(undefined, id)}
+      onMenuClick={handleMenuClick}
+    />
+    {/* 保留操作選單與刪除對話框 */}
+    <Menu anchorEl={anchorEl} open={Boolean(anchorEl)} onClose={handleMenuClose}>
+      <MenuItem onClick={() => handleAction("更新")}>更新</MenuItem>
+      <MenuItem onClick={() => handleAction("下載")}>下載</MenuItem>
+      <MenuItem onClick={() => openDeleteDialog()}>刪除</MenuItem>
+    </Menu>
+    <DeleteWarningDialog
+      title="刪除資料表格"
+      content="確定要刪除這個資料表格嗎？此操作無法復原。"
+      open={openDialog}
+      handleClose={closeDeleteDialog}
+      handleComfirm={handleConfirmDelete}
+    />
+  </Box>
+);
+```
+
+---
+
+這樣你就完成了第一步抽象化，未來只要換成 `DashboardInfo` 或 `UserInfo`，只要轉成 `GenericItem[]` 就能直接使用！
+
+如果你希望我幫你進一步抽象操作選單（Menu + Dialog），也可以幫你做成 `GenericItemActions` 元件。要繼續嗎？
+
+### 推薦兩問
+- 幫我抽象化操作選單 GenericItemActions 元件
+- 示範如何在 DashboardList 用 GenericListView
+
+## Copilot 提問 列表代碼抽象化-動作抽象化
+幫我抽象化操作選單 GenericItemActions 元件
+
+## Copilot 回答 列表代碼抽象化-動作抽象化
+太好了！我們現在來抽象化操作選單，建立一個通用的 `GenericItemActions` 元件，讓你在 `DataTableList`、`DashboardList`、`UserList` 等地方都能重複使用。
+
+---
+
+### ✅ 1. 建立 `GenericItemActions.tsx`
+
+```tsx
+// src/components/common/GenericItemActions.tsx
+import {
+  IconButton,
+  Menu,
+  MenuItem,
+  Dialog,
+  DialogTitle,
+  DialogContent,
+  DialogContentText,
+  DialogActions,
+  Button,
+} from "@mui/material";
+import MoreVertIcon from "@mui/icons-material/MoreVert";
+import { useState } from "react";
+
+export interface GenericItemActionsProps {
+  itemId: string;
+  onAction: (action: string, itemId: string) => void;
+  actions: string[]; // 例如 ["更新", "下載", "刪除"]
+  confirmDelete?: boolean;
+  deleteTitle?: string;
+  deleteContent?: string;
+}
+
+export const GenericItemActions = ({
+  itemId,
+  onAction,
+  actions,
+  confirmDelete = false,
+  deleteTitle = "刪除項目",
+  deleteContent = "確定要刪除這個項目嗎？此操作無法復原。",
+}: GenericItemActionsProps) => {
+  const [anchorEl, setAnchorEl] = useState<null | HTMLElement>(null);
+  const [openDialog, setOpenDialog] = useState(false);
+
+  const handleMenuClick = (event: React.MouseEvent<HTMLElement>) => {
+    setAnchorEl(event.currentTarget);
+  };
+
+  const handleMenuClose = () => {
+    setAnchorEl(null);
+  };
+
+  const handleActionClick = (action: string) => {
+    if (action === "刪除" && confirmDelete) {
+      setOpenDialog(true);
+    } else {
+      onAction(action, itemId);
+      handleMenuClose();
+    }
+  };
+
+  const handleConfirmDelete = () => {
+    onAction("刪除", itemId);
+    setOpenDialog(false);
+    handleMenuClose();
+  };
+
+  return (
+    <>
+      <IconButton onClick={handleMenuClick}>
+        <MoreVertIcon />
+      </IconButton>
+      <Menu anchorEl={anchorEl} open={Boolean(anchorEl)} onClose={handleMenuClose}>
+        {actions.map((action) => (
+          <MenuItem key={action} onClick={() => handleActionClick(action)}>
+            {action}
+          </MenuItem>
+        ))}
+      </Menu>
+      {confirmDelete && (
+        <Dialog open={openDialog} onClose={() => setOpenDialog(false)}>
+          <DialogTitle>{deleteTitle}</DialogTitle>
+          <DialogContent>
+            <DialogContentText>{deleteContent}</DialogContentText>
+          </DialogContent>
+          <DialogActions>
+            <Button onClick={() => setOpenDialog(false)}>取消</Button>
+            <Button onClick={handleConfirmDelete} color="error">確定刪除</Button>
+          </DialogActions>
+        </Dialog>
+      )}
+    </>
+  );
+};
+```
+
+---
+
+### ✅ 2. 在 `DataTableList.tsx` 中使用
+
+你可以把原本的 `Menu` 和 `DeleteWarningDialog` 移除，改用：
+
+```tsx
+import { GenericItemActions } from "../common/GenericItemActions";
+
+const handleAction = (action: string, id: string) => {
+  console.log(`對表格 ${id} 執行操作: ${action}`);
+  if (action === "刪除") {
+    window.api.deleteTable(id);
+    refreshTableInfos();
+  }
+  // 其他操作邏輯...
+};
+```
+
+然後在 `GenericListView` 的 `onMenuClick` 中改為：
+
+```tsx
+onMenuClick={(e, id) => {
+  // 直接在卡片或列表中渲染 GenericItemActions
+  // 或你也可以在 GenericListView 中加入 renderActions(id) 的 slot
+}}
+```
+
+或者你也可以在 `GenericListView` 中加入一個 `renderActions` prop：
+
+```tsx
+renderActions?: (id: string) => React.ReactNode;
+```
+
+然後在卡片或列表中這樣使用：
+
+```tsx
+{renderActions?.(item.id)}
+```
+
+---
+
+### ✅ 優點
+
+- 所有操作選單與刪除確認邏輯集中管理
+- 可重複使用於不同資料型別
+- 支援自訂操作項目與刪除提示文字
+
+---
+
+是否需要我幫你整合 `GenericListView` + `GenericItemActions` 的完整範例？或者你想先在 `DashboardList` 中試用看看？
+
+### 推薦兩問
+- 幫我整合 GenericListView 和 GenericItemActions 的完整範例
+- 示範如何在 DashboardList 用這套抽象元件
+
+## Gemini 提問 上傳狀態面板抽象化
+這樣拆解還是合併起來比較好
+
+```tsx
+// src/components/DataTablesPage/UploadStatusPanel.tsx
+import React, { useState, useCallback } from "react";
+import {
+  Box,
+  Typography,
+  List,
+  ListItemText,
+  IconButton,
+  Dialog,
+  DialogTitle,
+  DialogContent,
+  DialogActions,
+  Button,
+  Snackbar,
+} from "@mui/material";
+import CloseIcon from "@mui/icons-material/Close";
+import ContentCopyIcon from "@mui/icons-material/ContentCopy";
+
+import { useUploadStore } from "../../stores/uploadStore";
+
+import { STANDARD_JSON_EXAMPLE } from "../../utils";
+import { UploadStatusBar } from "./UploadStatusBar";
+
+// --- 標準格式對話框元件 ---
+interface StandardFormatDialogProps {
+  open: boolean;
+  onClose: () => void;
+}
+
+const StandardFormatDialog: React.FC<StandardFormatDialogProps> = ({
+  open,
+  onClose,
+}) => {
+  const [snackbarOpen, setSnackbarOpen] = useState(false);
+
+  const handleCopy = useCallback(() => {
+    // 複製標準 JSON 範例到剪貼簿
+    navigator.clipboard.writeText(STANDARD_JSON_EXAMPLE).then(() => {
+      setSnackbarOpen(true);
+    });
+  }, []);
+
+  const handleSnackbarClose = (
+    _event: React.SyntheticEvent | Event,
+    reason?: string
+  ) => {
+    if (reason === "clickaway") {
+      return;
+    }
+    setSnackbarOpen(false);
+  };
+
+  return (
+    <>
+      <Dialog
+        open={open}
+        onClose={onClose}
+        aria-labelledby="standard-format-dialog-title"
+        maxWidth="md"
+        fullWidth
+      >
+        <DialogTitle id="standard-format-dialog-title">
+          標準 JSON 檔案格式範例
+          <IconButton
+            aria-label="close"
+            onClick={onClose}
+            sx={{
+              position: "absolute",
+              right: 8,
+              top: 8,
+              color: (theme) => theme.palette.grey[500],
+            }}
+          >
+            <CloseIcon />
+          </IconButton>
+        </DialogTitle>
+        <DialogContent dividers>
+          <Typography gutterBottom variant="subtitle1">
+            請確保您的 JSON 檔案符合以下格式規範：
+          </Typography>
+          <List dense sx={{ ml: 2, mb: 2 }}>
+            <ListItemText primary="- 必須是陣列（[ ]）" />
+            <ListItemText primary="- 陣列元素並須是非陣列的物件（{ }）" />
+            <ListItemText primary="- 所有物件（資料列）都應有相同的鍵（欄位名稱）" />
+          </List>
+          <Box
+            sx={{
+              backgroundColor: "#f5f5f5",
+              p: 2,
+              borderRadius: 1,
+              overflowX: "auto",
+              position: "relative",
+            }}
+          >
+            <IconButton
+              aria-label="copy"
+              onClick={handleCopy}
+              size="small"
+              sx={{
+                position: "absolute",
+                top: 8,
+                right: 8,
+                color: "text.secondary",
+              }}
+            >
+              <ContentCopyIcon fontSize="small" />
+            </IconButton>
+            <pre style={{ margin: 0, whiteSpace: "pre-wrap" }}>
+              <code>{STANDARD_JSON_EXAMPLE}</code>
+            </pre>
+          </Box>
+        </DialogContent>
+        <DialogActions>
+          <Button onClick={onClose} color="primary" variant="contained">
+            關閉
+          </Button>
+        </DialogActions>
+      </Dialog>
+      <Snackbar
+        open={snackbarOpen}
+        autoHideDuration={3000}
+        onClose={handleSnackbarClose}
+        message="標準 JSON 格式已複製！"
+      />
+    </>
+  );
+};
+
+// --- UploadStatusPanel 元件 ---
+
+export const UploadStatusPanel: React.FC = () => {
+  const uploads = useUploadStore((state) => state.uploads);
+
+  // 控制對話框的開關狀態
+  const [isDialogOpen, setIsDialogOpen] = useState(false);
+
+  const handleOpenDialog = (e: React.MouseEvent) => {
+    e.preventDefault();
+    e.stopPropagation(); // 阻止事件冒泡到 AccordionSummary
+    setIsDialogOpen(true);
+  };
+
+  const handleCloseDialog = () => {
+    setIsDialogOpen(false);
+  };
+
+  if (uploads.length === 0) {
+    return (
+      <Box sx={{ p: 2, color: "text.secondary" }}>上傳狀態會顯示在這裡。</Box>
+    );
+  }
+
+  return (
+    <Box sx={{ p: 2 }}>
+      {/* 標準格式範例對話框 */}
+      <StandardFormatDialog open={isDialogOpen} onClose={handleCloseDialog} />
+      <List dense sx={{ mt: 1 }}>
+        {uploads.map((upload) => (
+          <UploadStatusBar
+            fileuploadStatus={upload}
+            handleOpenDialog={handleOpenDialog}
+          />
+        ))}
+      </List>
+    </Box>
+  );
+};
+```
+
+```tsx
+// src/components/DataTablesPage/UploadStatusBar.tsx
+import React from "react";
+import {
+  Box,
+  Typography,
+  ListItemText,
+  LinearProgress,
+  IconButton,
+  ListItemIcon,
+  Link,
+} from "@mui/material";
+import CheckCircleIcon from "@mui/icons-material/CheckCircle";
+import ErrorIcon from "@mui/icons-material/Error";
+import CloudUploadIcon from "@mui/icons-material/CloudUpload";
+import CloseIcon from "@mui/icons-material/Close";
+
+import {
+  useUploadStore,
+  type FileUploadStatus,
+} from "../../stores/uploadStore";
+
+import { ExpandableStatusBar } from "../common/ExpandableStatusBar";
+
+// --- UploadStatusPanel 元件 ---
+
+const getIcon = (status: FileUploadStatus["status"]) => {
+  switch (status) {
+    case "success":
+      return <CheckCircleIcon color="success" sx={{ mr: 1 }} />;
+    case "failed":
+      return <ErrorIcon color="error" sx={{ mr: 1 }} />;
+    case "uploading":
+    default:
+      return <CloudUploadIcon color="primary" sx={{ mr: 1 }} />;
+  }
+};
+
+interface Props {
+  fileuploadStatus: FileUploadStatus;
+  handleOpenDialog: (e: React.MouseEvent) => void;
+}
+
+export const UploadStatusBar: React.FC<Props> = ({
+  fileuploadStatus: upload,
+  handleOpenDialog,
+}) => {
+  const removeUpload = useUploadStore((state) => state.removeUpload);
+  const toggleExpand = useUploadStore((state) => state.toggleExpand);
+
+  return (
+    <ExpandableStatusBar
+      key={upload.id}
+      isExpanded={upload.isExpanded}
+      handleExpanded={() => toggleExpand(upload.id)}
+      title={
+        <>
+          <ListItemIcon sx={{ minWidth: "40px" }}>
+            {getIcon(upload.status)}
+          </ListItemIcon>
+          <ListItemText
+            primary={
+              <Typography variant="body2" sx={{ fontWeight: "bold" }}>
+                {upload.fileName}
+              </Typography>
+            }
+            secondary={
+              <Typography variant="body2" color="text.secondary">
+                {upload.status === "uploading"
+                  ? "上傳中..."
+                  : upload.status === "success"
+                    ? "上傳成功"
+                    : "上傳失敗"}
+              </Typography>
+            }
+          />
+          {(upload.status === "success" || upload.status === "failed") && (
+            <IconButton
+              edge="end"
+              aria-label="delete"
+              onClick={(e) => {
+                e.stopPropagation(); // 阻止事件冒泡到 AccordionSummary
+                removeUpload(upload.id);
+              }}
+              size="small"
+              sx={{ ml: 1 }}
+            >
+              <CloseIcon />
+            </IconButton>
+          )}
+        </>
+      }
+      detail={
+        <>
+          {upload.status === "uploading" && <LinearProgress />}
+          {upload.status === "failed" && (
+            <Box
+              sx={{
+                mt: 1,
+                p: 1,
+                backgroundColor: "rgba(255, 0, 0, 0.05)",
+                borderRadius: 1,
+              }}
+            >
+              <Typography variant="body2" color="error">
+                錯誤原因: {upload.error}
+              </Typography>
+              {/* 檢查是否有 JSON 格式錯誤前綴，顯示連結 */}
+              {upload.error && upload.errorName === "ValidationError" && (
+                <Link
+                  component="button"
+                  variant="body2"
+                  onClick={handleOpenDialog}
+                  sx={{ mt: 1, display: "block" }}
+                >
+                  檢視標準 JSON 格式範例
+                </Link>
+              )}
+            </Box>
+          )}
+        </>
+      }
+    />
+  );
+};
+```
+
+```tsx
+// src/components/common/ExpandableStatusBar.tsx
+import React from "react";
+import {
+  Paper,
+  AccordionDetails,
+  Accordion,
+  AccordionSummary,
+} from "@mui/material";
+
+interface Props {
+  key: React.Key;
+  isExpanded?: boolean;
+  handleExpanded?:
+    | ((event: React.SyntheticEvent, expanded: boolean) => void)
+    | undefined;
+  title: React.ReactElement;
+  detail: React.ReactElement;
+}
+export const ExpandableStatusBar: React.FC<Props> = ({
+  key,
+  isExpanded,
+  handleExpanded,
+  title,
+  detail,
+}) => {
+  return (
+    <Paper key={key} elevation={1} sx={{ mb: 1 }}>
+      <Accordion
+        expanded={isExpanded}
+        onChange={handleExpanded}
+        sx={{
+          "&.MuiAccordion-root": {
+            boxShadow: "none",
+            "&::before": { display: "none" },
+          },
+        }}
+      >
+        <AccordionSummary
+          aria-controls={`panel-${key}-content`}
+          id={`panel-${key}-header`}
+          sx={{
+            minHeight: "48px",
+            "&.Mui-expanded": { minHeight: "48px" },
+            "& .MuiAccordionSummary-content": {
+              alignItems: "center",
+              margin: "12px 0",
+              "&.Mui-expanded": { margin: "12px 0" },
+            },
+          }}
+        >
+          {title}
+        </AccordionSummary>
+        <AccordionDetails>{detail}</AccordionDetails>
+      </Accordion>
+    </Paper>
+  );
+};
+```
+
+## Gemini 回答 上傳狀態面板抽象化
+對於你提供的這段程式碼，**將 `StandardFormatDialog` 元件從 `UploadStatusPanel.tsx` 中拆分出來，放到一個獨立的檔案會更好**。
+
+---
+
+### 拆分的理由 (推薦做法) 🚀
+
+將 `StandardFormatDialog` 拆分出來，例如放到 `src/components/DataTablesPage/StandardFormatDialog.tsx`，可以帶來以下好處：
+
+#### 1. 職責分離 (Separation of Concerns)
+* **清晰度**：`UploadStatusPanel` 的核心職責是管理和呈現**上傳狀態列表** (`UploadStatusBar`s)。`StandardFormatDialog` 的職責是呈現**JSON 格式範例對話框**。將它們分離可以讓每個檔案只專注於一個獨立的功能，提高元件的**內聚性 (Cohesion)**。
+* **檔案長度**：`UploadStatusPanel.tsx` 檔案目前已經較長。拆分後，`UploadStatusPanel.tsx` 會更簡潔，更容易閱讀和維護。
+
+#### 2. 重複利用性 (Reusability)
+* 如果未來應用程式的其他部分也需要顯示這個「標準 JSON 格式範例」對話框，你就可以直接從獨立的 `StandardFormatDialog.tsx` 檔案中匯入並使用它，而不需要在多個地方複製程式碼或依賴 `UploadStatusPanel`。
+
+#### 3. 測試性 (Testability)
+* 獨立的元件更容易進行單元測試。你可以單獨測試 `StandardFormatDialog` 的開啟/關閉邏輯、複製功能和 Snackbar 顯示，而無需考慮 `UploadStatusPanel` 的其他邏輯。
+
+---
+
+### 合併的理由 (目前的做法) 🤔
+
+目前將 `StandardFormatDialog` 放在 `UploadStatusPanel.tsx` 內作為私有或輔助元件也有其道理，但通常適用於更簡單的情況：
+
+* **強烈耦合**：如果 `StandardFormatDialog` **只會**且**永遠只會**被 `UploadStatusPanel` 使用，並且它們之間的邏輯或狀態緊密相依，可以考慮放在一起。
+    * *但以目前的程式碼來看，它們的相依性只有 `open` 和 `onClose` 兩個簡單的 props，耦合度並不高。*
+* **小型元件**：如果 `StandardFormatDialog` 的程式碼非常少（例如只有 10-20 行），放在一起可以減少檔案數量。
+    * *但你提供的 `StandardFormatDialog` 包含了多個 `useState`、`useCallback`、MUI 元件和複雜的 JSX 結構，算是一個中等大小的獨立功能，將其視為一個獨立的單元更合適。*
+
+---
+
+### 結論與建議 💡
+
+✅ **建議的做法：拆分**
+
+將 `StandardFormatDialog` 拆分為一個獨立的檔案。
+
+**程式碼調整範例：**
+
+1.  **新建檔案：** `src/components/DataTablesPage/StandardFormatDialog.tsx`
+2.  **移動內容：** 將原 `UploadStatusPanel.tsx` 中 `StandardFormatDialogProps` 介面、`StandardFormatDialog` 元件以及相關的 import (除了 `UploadStatusPanel` 專用的) 移至新檔案並 `export`。
+3.  **更新 `UploadStatusPanel.tsx`：** 刪除舊的元件定義，並從新的路徑 `import { StandardFormatDialog } from "./StandardFormatDialog";`。
+
+## Gemini 提問 上傳狀態面板抽象化2
+```tsx
+// src/components/DataTablesPage/UploadStatusPanel.tsx
+import React, { useState, useCallback } from "react";
+import {
+  Box,
+  Typography,
+  List,
+  ListItemText,
+  LinearProgress,
+  Paper,
+  IconButton,
+  AccordionDetails,
+  Accordion,
+  AccordionSummary,
+  ListItemIcon,
+  Dialog,
+  DialogTitle,
+  DialogContent,
+  DialogActions,
+  Button,
+  Link,
+  Snackbar,
+} from "@mui/material";
+import CheckCircleIcon from "@mui/icons-material/CheckCircle";
+import ErrorIcon from "@mui/icons-material/Error";
+import CloudUploadIcon from "@mui/icons-material/CloudUpload";
+import CloseIcon from "@mui/icons-material/Close";
+import ContentCopyIcon from "@mui/icons-material/ContentCopy";
+
+import {
+  useUploadStore,
+  type FileUploadStatus,
+} from "../../stores/uploadStore";
+
+import { STANDARD_JSON_EXAMPLE } from "../../utils";
+
+// --- 標準格式對話框元件 ---
+interface StandardFormatDialogProps {
+  open: boolean;
+  onClose: () => void;
+}
+
+const StandardFormatDialog: React.FC<StandardFormatDialogProps> = ({
+  open,
+  onClose,
+}) => {
+  const [snackbarOpen, setSnackbarOpen] = useState(false);
+
+  const handleCopy = useCallback(() => {
+    // 複製標準 JSON 範例到剪貼簿
+    navigator.clipboard.writeText(STANDARD_JSON_EXAMPLE).then(() => {
+      setSnackbarOpen(true);
+    });
+  }, []);
+
+  const handleSnackbarClose = (
+    _event: React.SyntheticEvent | Event,
+    reason?: string
+  ) => {
+    if (reason === "clickaway") {
+      return;
+    }
+    setSnackbarOpen(false);
+  };
+
+  return (
+    <>
+      <Dialog
+        open={open}
+        onClose={onClose}
+        aria-labelledby="standard-format-dialog-title"
+        maxWidth="md"
+        fullWidth
+      >
+        <DialogTitle id="standard-format-dialog-title">
+          標準 JSON 檔案格式範例
+          <IconButton
+            aria-label="close"
+            onClick={onClose}
+            sx={{
+              position: "absolute",
+              right: 8,
+              top: 8,
+              color: (theme) => theme.palette.grey[500],
+            }}
+          >
+            <CloseIcon />
+          </IconButton>
+        </DialogTitle>
+        <DialogContent dividers>
+          <Typography gutterBottom variant="subtitle1">
+            請確保您的 JSON 檔案符合以下格式規範：
+          </Typography>
+          <List dense sx={{ ml: 2, mb: 2 }}>
+            <ListItemText primary="- 必須是陣列（[ ]）" />
+            <ListItemText primary="- 陣列元素並須是非陣列的物件（{ }）" />
+            <ListItemText primary="- 所有物件（資料列）都應有相同的鍵（欄位名稱）" />
+          </List>
+          <Box
+            sx={{
+              backgroundColor: "#f5f5f5",
+              p: 2,
+              borderRadius: 1,
+              overflowX: "auto",
+              position: "relative",
+            }}
+          >
+            <IconButton
+              aria-label="copy"
+              onClick={handleCopy}
+              size="small"
+              sx={{
+                position: "absolute",
+                top: 8,
+                right: 8,
+                color: "text.secondary",
+              }}
+            >
+              <ContentCopyIcon fontSize="small" />
+            </IconButton>
+            <pre style={{ margin: 0, whiteSpace: "pre-wrap" }}>
+              <code>{STANDARD_JSON_EXAMPLE}</code>
+            </pre>
+          </Box>
+        </DialogContent>
+        <DialogActions>
+          <Button onClick={onClose} color="primary" variant="contained">
+            關閉
+          </Button>
+        </DialogActions>
+      </Dialog>
+      <Snackbar
+        open={snackbarOpen}
+        autoHideDuration={3000}
+        onClose={handleSnackbarClose}
+        message="標準 JSON 格式已複製！"
+      />
+    </>
+  );
+};
+// --- UploadStatusPanel 元件 ---
+
+const getIcon = (status: FileUploadStatus["status"]) => {
+  switch (status) {
+    case "success":
+      return <CheckCircleIcon color="success" sx={{ mr: 1 }} />;
+    case "failed":
+      return <ErrorIcon color="error" sx={{ mr: 1 }} />;
+    case "uploading":
+    default:
+      return <CloudUploadIcon color="primary" sx={{ mr: 1 }} />;
+  }
+};
+
+export const UploadStatusPanel: React.FC = () => {
+  const uploads = useUploadStore((state) => state.uploads);
+  const removeUpload = useUploadStore((state) => state.removeUpload);
+  const toggleExpand = useUploadStore((state) => state.toggleExpand);
+
+  // 控制對話框的開關狀態
+  const [isDialogOpen, setIsDialogOpen] = useState(false);
+
+  const handleOpenDialog = (e: React.MouseEvent) => {
+    e.preventDefault();
+    e.stopPropagation(); // 阻止事件冒泡到 AccordionSummary
+    setIsDialogOpen(true);
+  };
+
+  const handleCloseDialog = () => {
+    setIsDialogOpen(false);
+  };
+
+  if (uploads.length === 0) {
+    return (
+      <Box sx={{ p: 2, color: "text.secondary" }}>上傳狀態會顯示在這裡。</Box>
+    );
+  }
+
+  return (
+    <Box sx={{ p: 2 }}>
+      {/* 標準格式範例對話框 */}
+      <StandardFormatDialog open={isDialogOpen} onClose={handleCloseDialog} />
+      <List dense sx={{ mt: 1 }}>
+        {uploads.map((upload) => (
+          <Paper key={upload.id} elevation={1} sx={{ mb: 1 }}>
+            <Accordion
+              expanded={upload.isExpanded}
+              onChange={() => toggleExpand(upload.id)}
+              sx={{
+                "&.MuiAccordion-root": {
+                  boxShadow: "none",
+                  "&::before": { display: "none" },
+                },
+              }}
+            >
+              <AccordionSummary
+                aria-controls={`panel-${upload.id}-content`}
+                id={`panel-${upload.id}-header`}
+                sx={{
+                  minHeight: "48px",
+                  "&.Mui-expanded": { minHeight: "48px" },
+                  "& .MuiAccordionSummary-content": {
+                    alignItems: "center",
+                    margin: "12px 0",
+                    "&.Mui-expanded": { margin: "12px 0" },
+                  },
+                }}
+              >
+                <ListItemIcon sx={{ minWidth: "40px" }}>
+                  {getIcon(upload.status)}
+                </ListItemIcon>
+                <ListItemText
+                  primary={
+                    <Typography variant="body2" sx={{ fontWeight: "bold" }}>
+                      {upload.fileName}
+                    </Typography>
+                  }
+                  secondary={
+                    <Typography variant="body2" color="text.secondary">
+                      {upload.status === "uploading"
+                        ? "上傳中..."
+                        : upload.status === "success"
+                          ? "上傳成功"
+                          : "上傳失敗"}
+                    </Typography>
+                  }
+                />
+                {(upload.status === "success" ||
+                  upload.status === "failed") && (
+                  <IconButton
+                    edge="end"
+                    aria-label="delete"
+                    onClick={(e) => {
+                      e.stopPropagation(); // 阻止事件冒泡到 AccordionSummary
+                      removeUpload(upload.id);
+                    }}
+                    size="small"
+                    sx={{ ml: 1 }}
+                  >
+                    <CloseIcon />
+                  </IconButton>
+                )}
+              </AccordionSummary>
+              <AccordionDetails>
+                {upload.status === "uploading" && <LinearProgress />}
+                {upload.status === "failed" && (
+                  <Box
+                    sx={{
+                      mt: 1,
+                      p: 1,
+                      backgroundColor: "rgba(255, 0, 0, 0.05)",
+                      borderRadius: 1,
+                    }}
+                  >
+                    <Typography variant="body2" color="error">
+                      錯誤原因: {upload.error}
+                    </Typography>
+                    {/* 檢查是否有 JSON 格式錯誤前綴，顯示連結 */}
+                    {upload.error && upload.errorName === "ValidationError" && (
+                      <Link
+                        component="button"
+                        variant="body2"
+                        onClick={handleOpenDialog}
+                        sx={{ mt: 1, display: "block" }}
+                      >
+                        檢視標準 JSON 格式範例
+                      </Link>
+                    )}
+                  </Box>
+                )}
+              </AccordionDetails>
+            </Accordion>
+          </Paper>
+        ))}
+      </List>
+    </Box>
+  );
+};
+```
+
+VS
+
+```tsx
+// src/components/DataTablesPage/UploadStatusPanel.tsx
+import React, { useState, useCallback } from "react";
+import {
+  Box,
+  Typography,
+  List,
+  ListItemText,
+  IconButton,
+  Dialog,
+  DialogTitle,
+  DialogContent,
+  DialogActions,
+  Button,
+  Snackbar,
+} from "@mui/material";
+import CloseIcon from "@mui/icons-material/Close";
+import ContentCopyIcon from "@mui/icons-material/ContentCopy";
+
+import { useUploadStore } from "../../stores/uploadStore";
+
+import { STANDARD_JSON_EXAMPLE } from "../../utils";
+import { UploadStatusBar } from "./UploadStatusBar";
+
+// --- 標準格式對話框元件 ---
+interface StandardFormatDialogProps {
+  open: boolean;
+  onClose: () => void;
+}
+
+const StandardFormatDialog: React.FC<StandardFormatDialogProps> = ({
+  open,
+  onClose,
+}) => {
+  const [snackbarOpen, setSnackbarOpen] = useState(false);
+
+  const handleCopy = useCallback(() => {
+    // 複製標準 JSON 範例到剪貼簿
+    navigator.clipboard.writeText(STANDARD_JSON_EXAMPLE).then(() => {
+      setSnackbarOpen(true);
+    });
+  }, []);
+
+  const handleSnackbarClose = (
+    _event: React.SyntheticEvent | Event,
+    reason?: string
+  ) => {
+    if (reason === "clickaway") {
+      return;
+    }
+    setSnackbarOpen(false);
+  };
+
+  return (
+    <>
+      <Dialog
+        open={open}
+        onClose={onClose}
+        aria-labelledby="standard-format-dialog-title"
+        maxWidth="md"
+        fullWidth
+      >
+        <DialogTitle id="standard-format-dialog-title">
+          標準 JSON 檔案格式範例
+          <IconButton
+            aria-label="close"
+            onClick={onClose}
+            sx={{
+              position: "absolute",
+              right: 8,
+              top: 8,
+              color: (theme) => theme.palette.grey[500],
+            }}
+          >
+            <CloseIcon />
+          </IconButton>
+        </DialogTitle>
+        <DialogContent dividers>
+          <Typography gutterBottom variant="subtitle1">
+            請確保您的 JSON 檔案符合以下格式規範：
+          </Typography>
+          <List dense sx={{ ml: 2, mb: 2 }}>
+            <ListItemText primary="- 必須是陣列（[ ]）" />
+            <ListItemText primary="- 陣列元素並須是非陣列的物件（{ }）" />
+            <ListItemText primary="- 所有物件（資料列）都應有相同的鍵（欄位名稱）" />
+          </List>
+          <Box
+            sx={{
+              backgroundColor: "#f5f5f5",
+              p: 2,
+              borderRadius: 1,
+              overflowX: "auto",
+              position: "relative",
+            }}
+          >
+            <IconButton
+              aria-label="copy"
+              onClick={handleCopy}
+              size="small"
+              sx={{
+                position: "absolute",
+                top: 8,
+                right: 8,
+                color: "text.secondary",
+              }}
+            >
+              <ContentCopyIcon fontSize="small" />
+            </IconButton>
+            <pre style={{ margin: 0, whiteSpace: "pre-wrap" }}>
+              <code>{STANDARD_JSON_EXAMPLE}</code>
+            </pre>
+          </Box>
+        </DialogContent>
+        <DialogActions>
+          <Button onClick={onClose} color="primary" variant="contained">
+            關閉
+          </Button>
+        </DialogActions>
+      </Dialog>
+      <Snackbar
+        open={snackbarOpen}
+        autoHideDuration={3000}
+        onClose={handleSnackbarClose}
+        message="標準 JSON 格式已複製！"
+      />
+    </>
+  );
+};
+
+// --- UploadStatusPanel 元件 ---
+
+export const UploadStatusPanel: React.FC = () => {
+  const uploads = useUploadStore((state) => state.uploads);
+
+  // 控制對話框的開關狀態
+  const [isDialogOpen, setIsDialogOpen] = useState(false);
+
+  const handleOpenDialog = (e: React.MouseEvent) => {
+    e.preventDefault();
+    e.stopPropagation(); // 阻止事件冒泡到 AccordionSummary
+    setIsDialogOpen(true);
+  };
+
+  const handleCloseDialog = () => {
+    setIsDialogOpen(false);
+  };
+
+  if (uploads.length === 0) {
+    return (
+      <Box sx={{ p: 2, color: "text.secondary" }}>上傳狀態會顯示在這裡。</Box>
+    );
+  }
+
+  return (
+    <Box sx={{ p: 2 }}>
+      {/* 標準格式範例對話框 */}
+      <StandardFormatDialog open={isDialogOpen} onClose={handleCloseDialog} />
+      <List dense sx={{ mt: 1 }}>
+        {uploads.map((upload) => (
+          <UploadStatusBar
+            fileuploadStatus={upload}
+            handleOpenDialog={handleOpenDialog}
+          />
+        ))}
+      </List>
+    </Box>
+  );
+};
+```
+
+```tsx
+// src/components/DataTablesPage/UploadStatusBar.tsx
+import React from "react";
+import {
+  Box,
+  Typography,
+  ListItemText,
+  LinearProgress,
+  IconButton,
+  ListItemIcon,
+  Link,
+} from "@mui/material";
+import CheckCircleIcon from "@mui/icons-material/CheckCircle";
+import ErrorIcon from "@mui/icons-material/Error";
+import CloudUploadIcon from "@mui/icons-material/CloudUpload";
+import CloseIcon from "@mui/icons-material/Close";
+
+import {
+  useUploadStore,
+  type FileUploadStatus,
+} from "../../stores/uploadStore";
+
+import { ExpandableStatusBar } from "../common/ExpandableStatusBar";
+
+// --- UploadStatusPanel 元件 ---
+
+const getIcon = (status: FileUploadStatus["status"]) => {
+  switch (status) {
+    case "success":
+      return <CheckCircleIcon color="success" sx={{ mr: 1 }} />;
+    case "failed":
+      return <ErrorIcon color="error" sx={{ mr: 1 }} />;
+    case "uploading":
+    default:
+      return <CloudUploadIcon color="primary" sx={{ mr: 1 }} />;
+  }
+};
+
+interface Props {
+  fileuploadStatus: FileUploadStatus;
+  handleOpenDialog: (e: React.MouseEvent) => void;
+}
+
+export const UploadStatusBar: React.FC<Props> = ({
+  fileuploadStatus: upload,
+  handleOpenDialog,
+}) => {
+  const removeUpload = useUploadStore((state) => state.removeUpload);
+  const toggleExpand = useUploadStore((state) => state.toggleExpand);
+
+  return (
+    <ExpandableStatusBar
+      key={upload.id}
+      isExpanded={upload.isExpanded}
+      handleExpanded={() => toggleExpand(upload.id)}
+      title={
+        <>
+          <ListItemIcon sx={{ minWidth: "40px" }}>
+            {getIcon(upload.status)}
+          </ListItemIcon>
+          <ListItemText
+            primary={
+              <Typography variant="body2" sx={{ fontWeight: "bold" }}>
+                {upload.fileName}
+              </Typography>
+            }
+            secondary={
+              <Typography variant="body2" color="text.secondary">
+                {upload.status === "uploading"
+                  ? "上傳中..."
+                  : upload.status === "success"
+                    ? "上傳成功"
+                    : "上傳失敗"}
+              </Typography>
+            }
+          />
+          {(upload.status === "success" || upload.status === "failed") && (
+            <IconButton
+              edge="end"
+              aria-label="delete"
+              onClick={(e) => {
+                e.stopPropagation(); // 阻止事件冒泡到 AccordionSummary
+                removeUpload(upload.id);
+              }}
+              size="small"
+              sx={{ ml: 1 }}
+            >
+              <CloseIcon />
+            </IconButton>
+          )}
+        </>
+      }
+      detail={
+        <>
+          {upload.status === "uploading" && <LinearProgress />}
+          {upload.status === "failed" && (
+            <Box
+              sx={{
+                mt: 1,
+                p: 1,
+                backgroundColor: "rgba(255, 0, 0, 0.05)",
+                borderRadius: 1,
+              }}
+            >
+              <Typography variant="body2" color="error">
+                錯誤原因: {upload.error}
+              </Typography>
+              {/* 檢查是否有 JSON 格式錯誤前綴，顯示連結 */}
+              {upload.error && upload.errorName === "ValidationError" && (
+                <Link
+                  component="button"
+                  variant="body2"
+                  onClick={handleOpenDialog}
+                  sx={{ mt: 1, display: "block" }}
+                >
+                  檢視標準 JSON 格式範例
+                </Link>
+              )}
+            </Box>
+          )}
+        </>
+      }
+    />
+  );
+};
+```
+
+```tsx
+// src/components/common/ExpandableStatusBar.tsx
+import React from "react";
+import {
+  Paper,
+  AccordionDetails,
+  Accordion,
+  AccordionSummary,
+} from "@mui/material";
+
+interface Props {
+  key: React.Key;
+  isExpanded?: boolean;
+  handleExpanded?:
+    | ((event: React.SyntheticEvent, expanded: boolean) => void)
+    | undefined;
+  title: React.ReactElement;
+  detail: React.ReactElement;
+}
+export const ExpandableStatusBar: React.FC<Props> = ({
+  key,
+  isExpanded,
+  handleExpanded,
+  title,
+  detail,
+}) => {
+  return (
+    <Paper key={key} elevation={1} sx={{ mb: 1 }}>
+      <Accordion
+        expanded={isExpanded}
+        onChange={handleExpanded}
+        sx={{
+          "&.MuiAccordion-root": {
+            boxShadow: "none",
+            "&::before": { display: "none" },
+          },
+        }}
+      >
+        <AccordionSummary
+          aria-controls={`panel-${key}-content`}
+          id={`panel-${key}-header`}
+          sx={{
+            minHeight: "48px",
+            "&.Mui-expanded": { minHeight: "48px" },
+            "& .MuiAccordionSummary-content": {
+              alignItems: "center",
+              margin: "12px 0",
+              "&.Mui-expanded": { margin: "12px 0" },
+            },
+          }}
+        >
+          {title}
+        </AccordionSummary>
+        <AccordionDetails>{detail}</AccordionDetails>
+      </Accordion>
+    </Paper>
+  );
+};
+```
+
+## Gemini 回答 上傳狀態面板抽象化2
+**推薦的做法是第二種：將功能拆分到獨立的元件檔案中。** 尤其將 `UploadStatusBar` 獨立出來是更佳的選擇。
+
+---
+
+### 拆分優勢分析 (第二個範例) ✅
+
+第二個範例的結構是：
+
+1.  `UploadStatusPanel.tsx`：負責管理整個上傳狀態列表的**總體狀態**（如：JSON 格式對話框的開關），並渲染 `UploadStatusBar` 列表。
+2.  `UploadStatusBar.tsx`：負責單個上傳項目的**視覺呈現邏輯**（如：根據狀態顯示不同圖標、刪除按鈕邏輯、錯誤詳情）。
+3.  `ExpandableStatusBar.tsx`：作為一個**通用/可重複使用**的樣板元件。
+
+#### 1. 職責分離與內聚性（Cohesion）
+
+* **`UploadStatusPanel`**：專注於**列表管理**、**數據獲取** (`useUploadStore`) 和**整體 UI 配置**。
+* **`UploadStatusBar`**：專注於**單一資料項目**的渲染細節。將 `getIcon` 函數和所有 `Accordion` 相關的 JSX 移至此處，大大提高了其內聚性。這使得元件更易於理解和維護。
+* **`StandardFormatDialog`**：雖然在兩個範例中都是內嵌在 `UploadStatusPanel.tsx` 中，但如你上一個問題的建議，將其獨立到自己的檔案會更好，但就你提供的兩個選項而言，將它放在 `UploadStatusPanel.tsx` 內作為私有輔助元件是可以接受的，因為它僅被 `UploadStatusPanel` 使用。
+
+#### 2. 檔案大小與可讀性
+
+* 第一個範例將 `UploadStatusBar` 的所有邏輯（超過 100 行的 JSX）都放在 `UploadStatusPanel.tsx` 的 **`uploads.map` 迴圈內**，導致 `UploadStatusPanel.tsx` 變得非常臃腫且難以閱讀。
+* 第二個範例的 `UploadStatusPanel.tsx` 則乾淨俐落，只透過 `<UploadStatusBar />` 呼叫外部元件，**大幅提高了可讀性**。
+
+#### 3. 可重複使用性與通用性
+
+* 在第一個範例中，單個狀態列的邏輯與 `UploadStatusPanel` **強烈耦合**。
+* 在第二個範例中，`UploadStatusBar` 作為一個獨立的元件，**更容易在應用程式其他地方重複使用**（即使目前沒有這樣的需求）。
+
+### 第一個範例的問題 (合併) ❌
+
+第一個範例將 **`ExpandableStatusBar.tsx`** 的內容直接合併到了 `UploadStatusPanel.tsx` 內的 `uploads.map` 迴圈中。
+
+* **通用元件的損失**：`ExpandableStatusBar` 顯然是一個**通用 UI 樣板**元件。將其合併到特定業務邏輯（上傳狀態）中，會讓它失去通用性，如果其他頁面需要類似的可展開狀態列，就必須重新複製程式碼。
+* **違反單一職責原則**：`UploadStatusPanel` 不僅負責列表管理，還要處理 **MUI `Accordion` 的所有樣式和結構細節**，這使得元件的職責過於複雜。
+
+**總結來說，第二種拆分方式符合現代 React/前端開發的最佳實踐：職責分離 (SoC)、高內聚 (High Cohesion) 和低耦合 (Low Coupling)。**
+
+## Gemini 提問 上傳狀態面板抽象化-進一步抽象化
+假設按照 第二個範例 且 StandardFormatDialog 也拆分，那還有哪裡要拆分或者重構的
+
+## Gemini 回答 上傳狀態面板抽象化-進一步抽象化
+根據您提供的第二個範例，並且假設您已經將 `StandardFormatDialog` 拆分到自己的檔案中，整體結構已經非常好了。
+
+但是，仍有兩個主要區域可以進行進一步的**拆分（Extract）和重構（Refactor）**，以進一步提高**元件的純粹性**和**程式碼的清晰度**。
+
+-----
+
+### 🚀 最佳重構與拆分點
+
+#### 1\. 將 `getIcon` 函數拆分
+
+`getIcon` 函數是一個純粹的**輔助函數 (Utility Function)**，它根據上傳狀態 (status) 返回對應的 MUI Icon 元件。
+
+  * **目前的檔案位置：** 位於 `UploadStatusBar.tsx` 檔案中。
+  * **重構建議：** 將其移動到一個獨立的輔助檔案，例如：`src/components/DataTablesPage/utils/uploadHelpers.ts` 或 `src/utils/upload/getIcon.ts`。
+
+##### 💡 這樣做的原因：
+
+  * **分離業務邏輯與表示層**：`getIcon` 雖然輸出 React 元件，但其功能本質上是一個**狀態映射邏輯**。將其移出 `UploadStatusBar` 元件的定義範圍，使 `UploadStatusBar.tsx` 檔案更專注於渲染邏輯本身。
+  * **潛在的重複使用**：如果未來在頁面的其他地方（例如一個總結面板）也需要顯示這些狀態圖標，這個函數可以被直接匯入使用，而不需要匯入整個 `UploadStatusBar` 元件。
+  * **提高測試性**：純粹的輔助函數更容易單獨進行單元測試。
+
+-----
+
+#### 2\. 重構 `UploadStatusBar` 內的標題/內容區塊
+
+`UploadStatusBar` 元件（即 `<ExpandableStatusBar />` 的 `title` 和 `detail` props）包含了複雜的 JSX 結構和條件渲染邏輯。雖然它們在 `UploadStatusBar` 內部，但可以將它們提取成**專屬的內部元件**或**輔助函數**，使 `UploadStatusBar` 的 `return` 語句更簡潔。
+
+##### 建議的重構方式：提取 `StatusDetail`
+
+您可以將處理錯誤訊息和進度條的 `detail` 內容提取為一個新的子元件，例如 `<UploadStatusDetail />`。
+
+**`UploadStatusBar.tsx` 重構前 (Detail 內容):**
+
+```tsx
+//...
+      detail={
+        <>
+          {upload.status === "uploading" && <LinearProgress />}
+          {upload.status === "failed" && (
+            <Box /* ... */ >
+              <Typography /* ... */ >
+                錯誤原因: {upload.error}
+              </Typography>
+              {/* 錯誤連結邏輯 */}
+              {upload.error && upload.errorName === "ValidationError" && (
+                <Link onClick={handleOpenDialog} /* ... */ >
+                  檢視標準 JSON 格式範例
+                </Link>
+              )}
+            </Box>
+          )}
+        </>
+      }
+//...
+```
+
+**重構後 (在 `UploadStatusBar.tsx` 內部定義或在單獨檔案定義):**
+
+```tsx
+// 假設在 UploadStatusBar.tsx 內部定義
+const UploadStatusDetail: React.FC<{
+  upload: FileUploadStatus;
+  handleOpenDialog: (e: React.MouseEvent) => void;
+}> = ({ upload, handleOpenDialog }) => {
+  if (upload.status === "uploading") {
+    return <LinearProgress />;
+  }
+
+  if (upload.status === "failed") {
+    return (
+      <Box /* ... */ >
+        {/* ...所有錯誤顯示和 Link 的 JSX... */}
+      </Box>
+    );
+  }
+  return null; // 或其他成功/閒置狀態的內容
+};
+
+export const UploadStatusBar: React.FC<Props> = ({
+  fileuploadStatus: upload,
+  handleOpenDialog,
+}) => {
+  // ...
+  return (
+    <ExpandableStatusBar
+      // ...
+      detail={
+        <UploadStatusDetail
+          upload={upload}
+          handleOpenDialog={handleOpenDialog}
+        />
+      }
+    />
+  );
+};
+```
+
+##### 💡 這樣做的原因：
+
+  * **簡化主要元件的渲染**：將複雜的條件邏輯和大量的 JSX 移入子元件，讓 `UploadStatusBar` 的 `return` 語句只負責組合邏輯。
+  * **更好的組織結構**：如果未來細節部分變得更複雜（例如新增更多狀態或資訊），您可以輕鬆地在子元件中擴展，而不會使父元件過度膨脹。
+
+-----
+
+### 總結
+
+您的第二個範例已經是很好的拆分方式。如果追求極致的清晰度和可維護性，這兩個進一步的重構步驟將是錦上添花：
+
+1.  **拆分 `getIcon` 輔助函數。** (最推薦)
+2.  **提取 `UploadStatusDetail` 子元件。** (高度推薦)
+
+## Gemini 提問 上傳狀態面板抽象化-標題抽象化
+那 ExpandableStatusBar title?
+
+## Gemini 回答 上傳狀態面板抽象化-標題抽象化
+你提到了 `<ExpandableStatusBar>` 的 `title` 部分。
+
+在第二個範例中，`UploadStatusBar.tsx` 裡定義的 `title` 包含了幾種不同的邏輯和元件：
+
+1.  **圖標邏輯**：調用 `getIcon(upload.status)`。
+2.  **檔案資訊**：`ListItemText` 顯示檔案名稱 (`upload.fileName`) 和狀態描述。
+3.  **刪除按鈕**：根據上傳狀態（成功或失敗）**有條件地渲染** `IconButton`。
+
+**針對 `title` 部分的重構建議是：將條件渲染的刪除按鈕邏輯提取成一個獨立的子元件。**
+
+-----
+
+### ✂️ 拆分刪除按鈕邏輯：`<RemoveUploadButton />`
+
+#### 重構點：`RemoveUploadButton` 元件
+
+雖然整個 `title` 部分的 JSX 複雜度不高，但將**條件渲染**和**事件處理**（`e.stopPropagation()` 和 `removeUpload` 動作）從 `title` 的主要結構中分離出來，可以讓 `title` 專注於檔案資訊的顯示。
+
+你可以創建一個專門的子元件，例如 `<RemoveUploadButton />`，並將其放在 `UploadStatusBar.tsx` 檔案的頂部（作為輔助元件）。
+
+```tsx
+// 在 UploadStatusBar.tsx 內...
+
+interface RemoveButtonProps {
+  uploadId: string;
+  status: FileUploadStatus["status"];
+}
+
+const RemoveUploadButton: React.FC<RemoveButtonProps> = ({ uploadId, status }) => {
+  // 從 store 中獲取刪除動作
+  const removeUpload = useUploadStore((state) => state.removeUpload);
+
+  // 僅在成功或失敗時顯示按鈕
+  if (status !== "success" && status !== "failed") {
+    return null;
+  }
+
+  return (
+    <IconButton
+      edge="end"
+      aria-label="delete"
+      onClick={(e) => {
+        e.stopPropagation(); // 關鍵：阻止事件冒泡
+        removeUpload(uploadId);
+      }}
+      size="small"
+      sx={{ ml: 1 }}
+    >
+      <CloseIcon />
+    </IconButton>
+  );
+};
+
+export const UploadStatusBar: React.FC<Props> = ({
+  fileuploadStatus: upload,
+  handleOpenDialog,
+}) => {
+  // ...
+  return (
+    <ExpandableStatusBar
+      // ...
+      title={
+        <>
+          <ListItemIcon sx={{ minWidth: "40px" }}>
+            {getIcon(upload.status)}
+          </ListItemIcon>
+          <ListItemText
+            primary={/* ... */}
+            secondary={/* ... */}
+          />
+          {/* 使用拆分後的元件 */}
+          <RemoveUploadButton
+            uploadId={upload.id}
+            status={upload.status}
+          />
+        </>
+      }
+      // ...
+    />
+  );
+};
+```
+
+#### 這樣重構的好處 🌟
+
+  * **清晰的意圖**：主元件的 `title` 部分現在更清楚地表明了它的內容：圖標、文字、然後是刪除按鈕。
+  * **封裝邏輯**：所有關於「**什麼時候**顯示刪除按鈕」和「**如何**刪除」的邏輯，包括必要的 `e.stopPropagation()`，都被完全封裝在 `<RemoveUploadButton />` 內部。
+  * **簡化 JSX**：移除了 `title` 內部的大段條件判斷 (`(upload.status === "success" || upload.status === "failed") && (...)`)，使父級元件更整潔。
+
+總結來說，除了先前建議的拆分 `StandardFormatDialog`、`getIcon` 和 `detail` 之外，**提取條件渲染的控制元件**（如刪除按鈕）是進一步優化元件結構的良好實踐。
+
+## Gemini 提問 上傳狀態面板抽象化-不對標題抽象化
+title 本身不拆分?
+
+## Gemini 回答 上傳狀態面板抽象化-不對標題抽象化
+對於 `<ExpandableStatusBar>` 的 `title` 本身，**我會建議保持它作為一個整體，不進行進一步的拆分。**
+
+雖然我們拆分了其中一個子元素（刪除按鈕），但將整個 `title` 視為一個單獨的 React 元件（例如 `<UploadStatusBarTitle />`）並沒有太大的好處，而且可能會導致**過度拆分（Over-engineering）**。
+
+-----
+
+### 為什麼不拆分整個 `title`
+
+#### 1\. 邏輯已足夠清晰
+
+`title` 內容已經是高度**聲明式**的組合：
+
+```tsx
+// UploadStatusBar.tsx 中的 title 結構
+title={
+  <>
+    <ListItemIcon> {/* 圖標，邏輯已拆分到 getIcon 函數 */}
+      {getIcon(upload.status)}
+    </ListItemIcon>
+    <ListItemText> {/* 檔案名稱與狀態描述 */}
+      {/* ... primary 和 secondary 的 Typography ... */}
+    </ListItemText>
+    <RemoveUploadButton> {/* 刪除按鈕，元件已拆分 */}
+      {/* ... */}
+    </RemoveUploadButton>
+  </>
+}
+```
+
+  * **圖標**的邏輯（`getIcon`）已經被建議拆分到工具函數中。
+  * **刪除按鈕**的條件渲染和事件處理（`onClick`）也已經被建議拆分到 `<RemoveUploadButton />` 元件中。
+
+剩下的 JSX 只是簡單地將三個部分（圖標、文字、按鈕）組合在一起，這是 **`UploadStatusBar`** 元件的**核心職責**之一，即**組裝**一個狀態列的標題。
+
+#### 2\. 避免不必要的 Props 傳遞
+
+如果將 `title` 拆分成 `<UploadStatusBarTitle upload={upload} />`：
+
+  * 你仍然需要將整個 `upload` 物件作為 props 傳遞進去。
+  * 這個新元件本身並沒有帶來新的、可重複使用的**獨立功能**，它只是將父元件的 `render` 邏輯向下推了一層。
+
+這增加了檔案數量，但沒有帶來顯著的**清晰度**或**可維用性**的提升，反而增加了調試時需要追蹤的元件層級。
+
+#### 結論 💡
+
+將 `getIcon` 提取為輔助函數，並將 `<RemoveUploadButton />` 提取為 `UploadStatusBar.tsx` 內部的輔助子元件後，原有的 `title` 結構已經是**簡潔且易讀**的組合。
+
+在這個階段，**保持 `title` 的組合邏輯在 `UploadStatusBar` 元件內部**，是實現程式碼清晰度與避免過度設計的最佳平衡。

--- a/docs/專案提示詞紀錄/專案提示詞紀錄-15.md
+++ b/docs/專案提示詞紀錄/專案提示詞紀錄-15.md
@@ -1,0 +1,1353 @@
+## Copilot 提問 列表代碼抽象化-操作按鈕進一步抽象
+以下拆解的優劣，是否推薦
+```
+diff --git a/src/components/DataTablesPage/DataTableList.tsx b/src/components/DataTablesPage/DataTableList.tsx
+index 1c25872..c9e4d78 100644
+--- a/src/components/DataTablesPage/DataTableList.tsx
++++ b/src/components/DataTablesPage/DataTableList.tsx
+@@ -1,11 +1,10 @@
+ // src/components/DataTablesPage/DataTableList.tsx
+-import { useState } from "react";
+ import { useNavigate } from "react-router-dom";
+-import { Box, Typography, Menu, MenuItem } from "@mui/material";
++import { Box, Typography } from "@mui/material";
+ import type { DataTableInfo, TableId } from "shared/types/dataTable";
+ import type { EditTableNavigateState } from "../../types";
+-import { DeleteWarningDialog } from "../common/DeleteWarningDialog";
+ import { GenericListView, type GenericItem } from "../common/GenericListView";
++import { GenericItemActions } from "../common/GenericItemActions";
+ 
+ interface Props {
+   dataTables: DataTableInfo[];
+@@ -19,9 +18,6 @@ export const DataTableList = ({
+   viewMode,
+   refreshTableInfos,
+ }: Props) => {
+-  const [anchorEl, setAnchorEl] = useState<null | HTMLElement>(null);
+-  const [selectedTableId, setSelectedTableId] = useState<TableId | null>(null);
+-  const [openDialog, setOpenDialog] = useState(false);
+   const navigate = useNavigate();
+ 
+   const handleTableClick = (tableId: TableId) => {
+@@ -35,38 +31,12 @@ export const DataTableList = ({
+     });
+   };
+ 
+-  const handleMenuClick = (
+-    event: React.MouseEvent<HTMLElement>,
+-    tableId: TableId
+-  ) => {
+-    setAnchorEl(event.currentTarget);
+-    setSelectedTableId(tableId);
+-  };
+-
+-  const handleMenuClose = () => {
+-    setAnchorEl(null);
+-    setSelectedTableId(null);
+-  };
+-
+-  const handleAction = (action: string) => {
+-    console.log(`對表格 ${selectedTableId} 執行操作: ${action}`);
+-    handleMenuClose();
+-  };
+-
+-  const closeDeleteDialog = () => {
+-    setOpenDialog(false);
+-    handleMenuClose();
+-  };
+-  const openDeleteDialog = () => {
+-    setOpenDialog(true);
+-    setAnchorEl(null);
+-  };
+-  const handleConfirmDelete = () => {
+-    console.log(`刪除表格 ${selectedTableId}`);
+-    window.api.deleteTable(selectedTableId!);
+-    setOpenDialog(false);
+-    handleMenuClose();
+-    refreshTableInfos();
++  const handleAction = (action: string, id: TableId) => {
++    console.log(`對表格 ${id} 執行操作: ${action}`);
++    if (action === "刪除") {
++      window.api.deleteTable(id);
++      refreshTableInfos();
++    }
+   };
+ 
+   // 將 DataTableInfo 轉換成 GenericItem
+@@ -90,26 +60,18 @@ export const DataTableList = ({
+           items={genericItems}
+           viewMode={viewMode}
+           onClickItem={(id) => handleTableClick(id)}
+-          onMenuClick={handleMenuClick}
++          renderActions={(id) => (
++            <GenericItemActions
++              itemId={id}
++              actions={["更新", "匯出", "刪除"]}
++              onAction={handleAction}
++              confirmDelete
++              deleteTitle="刪除儀表板"
++              deleteContent="確定要刪除這個儀表板嗎？此操作無法復原。"
++            />
++          )}
+         />
+       )}
+-      {/* 單一表格操作選單 */}
+-      <Menu
+-        anchorEl={anchorEl}
+-        open={Boolean(anchorEl)}
+-        onClose={handleMenuClose}
+-      >
+-        <MenuItem onClick={() => handleAction("更新")}>更新</MenuItem>
+-        <MenuItem onClick={() => handleAction("下載")}>下載</MenuItem>
+-        <MenuItem onClick={() => openDeleteDialog()}>刪除</MenuItem>
+-      </Menu>
+-      <DeleteWarningDialog
+-        title="刪除資料表格"
+-        content="確定要刪除這個資料表格嗎？此操作無法復原。"
+-        open={openDialog}
+-        handleClose={closeDeleteDialog}
+-        handleComfirm={handleConfirmDelete}
+-      />
+     </Box>
+   );
+ };
+diff --git a/src/components/common/GenericItemActions.tsx b/src/components/common/GenericItemActions.tsx
+new file mode 100644
+index 0000000..cf42b05
+--- /dev/null
++++ b/src/components/common/GenericItemActions.tsx
+@@ -0,0 +1,92 @@
++// src/components/common/GenericItemActions.tsx
++import {
++  IconButton,
++  Menu,
++  MenuItem,
++  Dialog,
++  DialogTitle,
++  DialogContent,
++  DialogContentText,
++  DialogActions,
++  Button,
++} from "@mui/material";
++import MoreVertIcon from "@mui/icons-material/MoreVert";
++import { useState } from "react";
++import type { TableId } from "shared/types/dataTable";
++
++export interface GenericItemActionsProps {
++  itemId: TableId;
++  actions: string[]; // 例如 ["更新", "下載", "刪除"]
++  onAction: (action: string, itemId: TableId) => void;
++  confirmDelete?: boolean;
++  deleteTitle?: string;
++  deleteContent?: string;
++}
++
++export const GenericItemActions = ({
++  itemId,
++  actions,
++  onAction,
++  confirmDelete = false,
++  deleteTitle = "刪除項目",
++  deleteContent = "確定要刪除這個項目嗎？此操作無法復原。",
++}: GenericItemActionsProps) => {
++  const [anchorEl, setAnchorEl] = useState<null | HTMLElement>(null);
++  const [openDialog, setOpenDialog] = useState(false);
++
++  const handleMenuClick = (event: React.MouseEvent<HTMLElement>) => {
++    setAnchorEl(event.currentTarget);
++  };
++
++  const handleMenuClose = () => {
++    setAnchorEl(null);
++  };
++
++  const handleActionClick = (action: string) => {
++    if (action === "刪除" && confirmDelete) {
++      setOpenDialog(true);
++    } else {
++      onAction(action, itemId);
++      handleMenuClose();
++    }
++  };
++
++  const handleConfirmDelete = () => {
++    onAction("刪除", itemId);
++    setOpenDialog(false);
++    handleMenuClose();
++  };
++
++  return (
++    <>
++      <IconButton onClick={handleMenuClick}>
++        <MoreVertIcon />
++      </IconButton>
++      <Menu
++        anchorEl={anchorEl}
++        open={Boolean(anchorEl)}
++        onClose={handleMenuClose}
++      >
++        {actions.map((action) => (
++          <MenuItem key={action} onClick={() => handleActionClick(action)}>
++            {action}
++          </MenuItem>
++        ))}
++      </Menu>
++      {confirmDelete && (
++        <Dialog open={openDialog} onClose={() => setOpenDialog(false)}>
++          <DialogTitle>{deleteTitle}</DialogTitle>
++          <DialogContent>
++            <DialogContentText>{deleteContent}</DialogContentText>
++          </DialogContent>
++          <DialogActions>
++            <Button onClick={() => setOpenDialog(false)}>取消</Button>
++            <Button onClick={handleConfirmDelete} color="error">
++              確定刪除
++            </Button>
++          </DialogActions>
++        </Dialog>
++      )}
++    </>
++  );
++};
+diff --git a/src/components/common/GenericListView.tsx b/src/components/common/GenericListView.tsx
+index 6409bc6..5e9a9b3 100644
+--- a/src/components/common/GenericListView.tsx
++++ b/src/components/common/GenericListView.tsx
+@@ -12,10 +12,8 @@ import {
+   TableHead,
+   TableRow,
+   Paper,
+-  IconButton,
+   Link,
+ } from "@mui/material";
+-import MoreVertIcon from "@mui/icons-material/MoreVert";
+ import type { DataRecord, TableId } from "shared/types/dataTable";
+ 
+ export interface GenericItem {
+@@ -29,14 +27,14 @@ export interface GenericListViewProps {
+   items: GenericItem[];
+   viewMode: "card" | "list";
+   onClickItem: (id: TableId) => void;
+-  onMenuClick?: (event: React.MouseEvent<HTMLElement>, id: TableId) => void;
++  renderActions?: (id: TableId) => React.ReactNode;
+ }
+ 
+ export const GenericListView = ({
+   items,
+   viewMode,
+   onClickItem,
+-  onMenuClick,
++  renderActions,
+ }: GenericListViewProps) => {
+   const renderList = () => (
+     <TableContainer component={Paper}>
+@@ -62,13 +60,7 @@ export const GenericListView = ({
+                     .map(([k, v]) => `${k}: ${v}`)
+                     .join(" / ")}
+               </TableCell>
+-              <TableCell align="right">
+-                {onMenuClick && (
+-                  <IconButton onClick={(e) => onMenuClick(e, item.id)}>
+-                    <MoreVertIcon />
+-                  </IconButton>
+-                )}
+-              </TableCell>
++              <TableCell align="right">{renderActions?.(item.id)}</TableCell>
+             </TableRow>
+           ))}
+         </TableBody>
+@@ -92,11 +84,7 @@ export const GenericListView = ({
+                 <Typography variant="h6">
+                   <Link onClick={() => onClickItem(item.id)}>{item.title}</Link>
+                 </Typography>
+-                {onMenuClick && (
+-                  <IconButton onClick={(e) => onMenuClick(e, item.id)}>
+-                    <MoreVertIcon />
+-                  </IconButton>
+-                )}
++                {renderActions?.(item.id)}
+               </Box>
+               <Typography variant="body2" color="text.secondary">
+                 上傳日期: {item.updated_at}
+```
+
+## Copilot 回答 列表代碼抽象化-操作按鈕進一步抽象
+非常不錯的重構 👍
+這次拆解 `DataTableList` → `GenericItemActions` 的改動在 **模組化、維護性與擴充性** 上是合理且推薦的。
+下面幫你做完整分析（含優劣勢與是否推薦）：
+
+---
+
+### 🧩 重構意圖
+
+你把「每個項目（item）的操作行為，例如更新、匯出、刪除」從 `DataTableList` 拆出成通用的 `GenericItemActions`，
+並修改 `GenericListView` 由 `onMenuClick` 改為 `renderActions`，允許客製化操作按鈕內容。
+這是一個典型的「**關注點分離 (Separation of Concerns)**」與「**抽象共用邏輯 (Reusable UI abstraction)**」重構。
+
+---
+
+### ✅ 優點（明確推薦理由）
+
+#### 1. 結構更乾淨、主元件更聚焦
+
+`DataTableList` 不再混雜 UI 狀態（menu/dialog 控制）邏輯，
+只需專注在業務邏輯（`handleAction`、`refreshTableInfos` 等），
+**維護難度下降，單元測試更容易撰寫**。
+
+#### 2. `GenericItemActions` 高度可重用
+
+抽出後可通用於：
+
+* 不同列表（如「報表清單」「儀表板清單」）
+* 不同動作集（不一定包含「刪除」）
+* 不同刪除提示內容
+
+→ 形成 **UI 操作層的統一入口**。
+
+#### 3. `GenericListView` 變得更通用
+
+原本透過 `onMenuClick` 綁死「一顆三點按鈕」，
+改為 `renderActions` 更彈性，可插入任何行為組件（icon、menu、dropdown、popover 等）。
+**這是高可擴充的介面設計方式**。
+
+#### 4. 刪除確認邏輯統一封裝
+
+刪除確認視窗從多個地方抽出成通用邏輯：
+
+* 不必每個 list 都重複維護對話框狀態
+* 對 UX 一致性有幫助
+
+#### 5. 維護成本明顯降低
+
+* 以後想改刪除對話框樣式或操作流程，只需改 `GenericItemActions`
+* 減少樣板式重複碼（`anchorEl`, `openDialog`, `handleMenuClick` 等）
+
+---
+
+### ⚠️ 缺點與可注意之處
+
+| 類型                                      | 說明                                                                                                  | 改進建議                                                              |          |           |
+| ----------------------------------------- | ----------------------------------------------------------------------------------------------------- | --------------------------------------------------------------------- | -------- | --------- |
+| **UI 狀態集中在子組件**                   | `GenericItemActions` 持有自己的 menu/dialog 狀態，若要外部控制（例如全域關閉所有 menu），目前不支援。 | 可考慮暴露 `onOpenChange` callback 或使用 context 管理。              |          |           |
+| **可測性稍降**                            | UI 狀態藏在內部，單元測試若要模擬刪除需透過 ref 或測試庫模擬點擊。                                    | 可考慮導出更多控制屬性（如 `openMenu`, `openDialog`）作為可選 props。 |          |           |
+| **文案綁定動作字串**                      | 目前用 `action === "刪除"` 這種字串判斷。若後期有多語系或 enum 化動作名稱會稍顯脆弱。                 | 改用 enum：`type ActionType = "update"                                | "export" | "delete"` |
+| **GenericItemActions 對刪除行為假設太強** | 預設只對 `"刪除"` 行為開對話框。若未來想要其他「需確認」行為（例如「重設」、「清空」）不易擴充。      | 可改為：`confirmActions?: string[]`，讓使用者指定哪些行為需要確認。   |          |           |
+
+---
+
+### 🏁 總結建議
+
+| 評估面向   | 評價  | 建議                                    |
+| ---------- | ----- | --------------------------------------- |
+| 可讀性     | ⭐⭐⭐⭐☆ | 明顯提升                                |
+| 可維護性   | ⭐⭐⭐⭐⭐ | 高度推薦                                |
+| 可重用性   | ⭐⭐⭐⭐☆ | 適合提煉到共用層                        |
+| 測試便利性 | ⭐⭐⭐☆☆ | 可考慮暴露更多控制接口                  |
+| 擴充性     | ⭐⭐⭐⭐☆ | 未來可加入更多 confirm 行為或 icon 模式 |
+
+**✅ 結論：非常推薦此重構。**
+這是從頁面層（`DataTableList`）中分離 UI 控制邏輯、向「通用 UI 組件層」演進的正確方向。
+若想進一步最佳化，可改成：
+
+```ts
+type ActionType = "update" | "export" | "delete";
+confirmActions?: ActionType[];
+onAction: (action: ActionType, id: TableId) => void;
+```
+
+這樣型別安全性與多語系支援性會更高。
+
+---
+
+是否希望我幫你產出進一步優化版（型別安全 + confirmActions 設計）？
+我可以直接給你完整優化後的 `GenericItemActions` 程式碼。
+
+
+## Copilot 提問 列表代碼抽象化-操作按鈕進一步抽象-範例
+好
+
+## Copilot 回答 列表代碼抽象化-操作按鈕進一步抽象-範例
+太好了 👍
+以下是優化後的 `GenericItemActions` ——
+強化了 **型別安全性、可擴充性與彈性控制**，同時保持簡潔可讀。
+
+---
+
+### ✅ 改進重點一覽
+
+| 改進項目             | 說明                                                                   |
+| -------------------- | ---------------------------------------------------------------------- |
+| 🔹 **型別安全**       | 使用 `enum` 或 union 型別取代字串動作比對。                            |
+| 🔹 **多動作確認支援** | 改用 `confirmActions` 陣列，可同時支援多個需確認的行為（不僅限刪除）。 |
+| 🔹 **文案與行為解耦** | 外部可傳入每個 action 的顯示文字，不再硬編「刪除」。                   |
+| 🔹 **外部控制開關**   | 暴露 `onOpenChange` callback，若未來想集中管理 menu/dialog 狀態可用。  |
+
+---
+
+### 🧱 最佳化版本：`GenericItemActions.tsx`
+
+```tsx
+// src/components/common/GenericItemActions.tsx
+import {
+  IconButton,
+  Menu,
+  MenuItem,
+  Dialog,
+  DialogTitle,
+  DialogContent,
+  DialogContentText,
+  DialogActions,
+  Button,
+} from "@mui/material";
+import MoreVertIcon from "@mui/icons-material/MoreVert";
+import { useState } from "react";
+import type { TableId } from "shared/types/dataTable";
+
+export type ActionType = "update" | "export" | "delete" | string;
+
+export interface GenericItemAction {
+  key: ActionType;
+  label: string;
+}
+
+export interface GenericItemActionsProps {
+  itemId: TableId;
+  actions: GenericItemAction[]; // e.g. [{ key: "update", label: "更新" }]
+  onAction: (action: ActionType, itemId: TableId) => void;
+
+  /** 哪些行為需要確認對話框 */
+  confirmActions?: ActionType[];
+
+  /** 對話框標題與內容，可根據動作自訂 */
+  confirmMessages?: Partial<Record<ActionType, { title: string; content: string }>>;
+
+  /** menu/dialog 開關狀態變更 callback */
+  onOpenChange?: (isOpen: boolean) => void;
+}
+
+export const GenericItemActions = ({
+  itemId,
+  actions,
+  onAction,
+  confirmActions = [],
+  confirmMessages = {},
+  onOpenChange,
+}: GenericItemActionsProps) => {
+  const [anchorEl, setAnchorEl] = useState<null | HTMLElement>(null);
+  const [pendingAction, setPendingAction] = useState<ActionType | null>(null);
+
+  const handleMenuClick = (event: React.MouseEvent<HTMLElement>) => {
+    setAnchorEl(event.currentTarget);
+    onOpenChange?.(true);
+  };
+
+  const handleMenuClose = () => {
+    setAnchorEl(null);
+    onOpenChange?.(false);
+  };
+
+  const handleActionClick = (action: ActionType) => {
+    if (confirmActions.includes(action)) {
+      setPendingAction(action);
+    } else {
+      onAction(action, itemId);
+      handleMenuClose();
+    }
+  };
+
+  const handleConfirm = () => {
+    if (pendingAction) onAction(pendingAction, itemId);
+    setPendingAction(null);
+    handleMenuClose();
+  };
+
+  const handleCancel = () => {
+    setPendingAction(null);
+  };
+
+  const currentConfirm = pendingAction
+    ? confirmMessages[pendingAction] ?? {
+        title: "確認操作",
+        content: "確定要執行這個操作嗎？此動作無法復原。",
+      }
+    : null;
+
+  return (
+    <>
+      <IconButton onClick={handleMenuClick}>
+        <MoreVertIcon />
+      </IconButton>
+
+      <Menu anchorEl={anchorEl} open={Boolean(anchorEl)} onClose={handleMenuClose}>
+        {actions.map(({ key, label }) => (
+          <MenuItem key={key} onClick={() => handleActionClick(key)}>
+            {label}
+          </MenuItem>
+        ))}
+      </Menu>
+
+      {currentConfirm && (
+        <Dialog open onClose={handleCancel}>
+          <DialogTitle>{currentConfirm.title}</DialogTitle>
+          <DialogContent>
+            <DialogContentText>{currentConfirm.content}</DialogContentText>
+          </DialogContent>
+          <DialogActions>
+            <Button onClick={handleCancel}>取消</Button>
+            <Button onClick={handleConfirm} color="error">
+              確定
+            </Button>
+          </DialogActions>
+        </Dialog>
+      )}
+    </>
+  );
+};
+```
+
+---
+
+### 💡 使用範例
+
+#### 在 `DataTableList.tsx` 中使用
+
+```tsx
+<GenericItemActions
+  itemId={id}
+  actions={[
+    { key: "update", label: "更新" },
+    { key: "export", label: "匯出" },
+    { key: "delete", label: "刪除" },
+  ]}
+  onAction={(action, id) => {
+    console.log(`對表格 ${id} 執行操作: ${action}`);
+    if (action === "delete") {
+      window.api.deleteTable(id);
+      refreshTableInfos();
+    }
+  }}
+  confirmActions={["delete"]}
+  confirmMessages={{
+    delete: {
+      title: "刪除資料表",
+      content: "確定要刪除此資料表嗎？此操作無法復原。",
+    },
+  }}
+/>
+```
+
+---
+
+### ⚙️ 可選擴充方向
+
+* ✅ 支援自定義 icon（例如 `icon={<DeleteIcon />}`）
+* ✅ 支援「多層選單」或「分組動作」
+* ✅ 支援 tooltip / hotkey 提示
+
+---
+
+是否希望我幫你順便改寫 `GenericListView` 的部分（讓 `renderActions` 更型別安全、支援空值處理）？
+那樣整個 list/action 結構會完全一致化、未來可重用到其他模組（例如報表清單或儀表板清單）。
+
+
+## Copilot 提問 上傳狀態面板抽象化-進一步抽象
+請以專業前端工程師眼光分析，此拆解是否適當，有必要，或者給出更好的拆解
+```
+diff --git a/src/components/DataTablesPage/StandardFormatDialog.tsx b/src/components/DataTablesPage/StandardFormatDialog.tsx
+new file mode 100644
+index 0000000..70d46d4
+--- /dev/null
++++ b/src/components/DataTablesPage/StandardFormatDialog.tsx
+@@ -0,0 +1,123 @@
++// src/components/DataTablesPage/StandardFormatDialog.tsx
++import React, { useState, useCallback } from "react";
++import {
++  Box,
++  Typography,
++  List,
++  ListItemText,
++  IconButton,
++  Dialog,
++  DialogTitle,
++  DialogContent,
++  DialogActions,
++  Button,
++  Snackbar,
++} from "@mui/material";
++import CloseIcon from "@mui/icons-material/Close";
++import ContentCopyIcon from "@mui/icons-material/ContentCopy";
++
++import { STANDARD_JSON_EXAMPLE } from "../../utils";
++
++interface StandardFormatDialogProps {
++  open: boolean;
++  onClose: () => void;
++}
++
++export const StandardFormatDialog: React.FC<StandardFormatDialogProps> = ({
++  open,
++  onClose,
++}) => {
++  const [snackbarOpen, setSnackbarOpen] = useState(false);
++
++  const handleCopy = useCallback(() => {
++    // 複製標準 JSON 範例到剪貼簿
++    navigator.clipboard.writeText(STANDARD_JSON_EXAMPLE).then(() => {
++      setSnackbarOpen(true);
++    });
++  }, []);
++
++  const handleSnackbarClose = (
++    _event: React.SyntheticEvent | Event,
++    reason?: string
++  ) => {
++    if (reason === "clickaway") {
++      return;
++    }
++    setSnackbarOpen(false);
++  };
++
++  return (
++    <>
++      <Dialog
++        open={open}
++        onClose={onClose}
++        aria-labelledby="standard-format-dialog-title"
++        maxWidth="md"
++        fullWidth
++      >
++        <DialogTitle id="standard-format-dialog-title">
++          標準 JSON 檔案格式範例
++          <IconButton
++            aria-label="close"
++            onClick={onClose}
++            sx={{
++              position: "absolute",
++              right: 8,
++              top: 8,
++              color: (theme) => theme.palette.grey[500],
++            }}
++          >
++            <CloseIcon />
++          </IconButton>
++        </DialogTitle>
++        <DialogContent dividers>
++          <Typography gutterBottom variant="subtitle1">
++            請確保您的 JSON 檔案符合以下格式規範：
++          </Typography>
++          <List dense sx={{ ml: 2, mb: 2 }}>
++            <ListItemText primary="- 必須是陣列（[ ]）" />
++            <ListItemText primary="- 陣列元素並須是非陣列的物件（{ }）" />
++            <ListItemText primary="- 所有物件（資料列）都應有相同的鍵（欄位名稱）" />
++          </List>
++          <Box
++            sx={{
++              backgroundColor: "#f5f5f5",
++              p: 2,
++              borderRadius: 1,
++              overflowX: "auto",
++              position: "relative",
++            }}
++          >
++            <IconButton
++              aria-label="copy"
++              onClick={handleCopy}
++              size="small"
++              sx={{
++                position: "absolute",
++                top: 8,
++                right: 8,
++                color: "text.secondary",
++              }}
++            >
++              <ContentCopyIcon fontSize="small" />
++            </IconButton>
++            <pre style={{ margin: 0, whiteSpace: "pre-wrap" }}>
++              <code>{STANDARD_JSON_EXAMPLE}</code>
++            </pre>
++          </Box>
++        </DialogContent>
++        <DialogActions>
++          <Button onClick={onClose} color="primary" variant="contained">
++            關閉
++          </Button>
++        </DialogActions>
++      </Dialog>
++      <Snackbar
++        open={snackbarOpen}
++        autoHideDuration={3000}
++        onClose={handleSnackbarClose}
++        message="標準 JSON 格式已複製！"
++      />
++    </>
++  );
++};
+diff --git a/src/components/DataTablesPage/UploadStatusBar.tsx b/src/components/DataTablesPage/UploadStatusBar.tsx
+new file mode 100644
+index 0000000..a2a09a5
+--- /dev/null
++++ b/src/components/DataTablesPage/UploadStatusBar.tsx
+@@ -0,0 +1,143 @@
++// src/components/DataTablesPage/UploadStatusBar.tsx
++import React from "react";
++import {
++  Box,
++  Typography,
++  ListItemText,
++  LinearProgress,
++  IconButton,
++  ListItemIcon,
++  Link,
++} from "@mui/material";
++import CloseIcon from "@mui/icons-material/Close";
++
++import {
++  useUploadStore,
++  type FileUploadStatus,
++} from "../../stores/uploadStore";
++
++import { ExpandableStatusBar } from "../common/ExpandableStatusBar";
++import { getIcon } from "./uploadHelpers";
++
++interface RemoveButtonProps {
++  uploadId: string;
++  status: FileUploadStatus["status"];
++}
++
++const RemoveUploadButton: React.FC<RemoveButtonProps> = ({
++  uploadId,
++  status,
++}) => {
++  // 從 store 中獲取刪除動作
++  const removeUpload = useUploadStore((state) => state.removeUpload);
++
++  // 僅在成功或失敗時顯示按鈕
++  if (status !== "success" && status !== "failed") {
++    return null;
++  }
++
++  return (
++    <IconButton
++      edge="end"
++      aria-label="delete"
++      onClick={(e) => {
++        e.stopPropagation(); // 關鍵：阻止事件冒泡
++        removeUpload(uploadId);
++      }}
++      size="small"
++      sx={{ ml: 1 }}
++    >
++      <CloseIcon />
++    </IconButton>
++  );
++};
++
++const UploadStatusDetail: React.FC<{
++  upload: FileUploadStatus;
++  handleOpenDialog: (e: React.MouseEvent) => void;
++}> = ({ upload, handleOpenDialog }) => {
++  if (upload.status === "uploading") {
++    return <LinearProgress />;
++  }
++
++  if (upload.status === "failed") {
++    return (
++      <Box
++        sx={{
++          mt: 1,
++          p: 1,
++          backgroundColor: "rgba(255, 0, 0, 0.05)",
++          borderRadius: 1,
++        }}
++      >
++        <Typography variant="body2" color="error">
++          錯誤原因: {upload.error}
++        </Typography>
++        {/* 檢查是否有 JSON 格式錯誤前綴，顯示連結 */}
++        {upload.error && upload.errorName === "ValidationError" && (
++          <Link
++            component="button"
++            variant="body2"
++            onClick={handleOpenDialog}
++            sx={{ mt: 1, display: "block" }}
++          >
++            檢視標準 JSON 格式範例
++          </Link>
++        )}
++      </Box>
++    );
++  }
++  return null; // 或其他成功/閒置狀態的內容
++};
++
++// --- UploadStatusBar 元件 ---
++
++interface UploadStatusBarProps {
++  fileuploadStatus: FileUploadStatus;
++  handleOpenDialog: (e: React.MouseEvent) => void;
++}
++
++export const UploadStatusBar: React.FC<UploadStatusBarProps> = ({
++  fileuploadStatus: upload,
++  handleOpenDialog,
++}) => {
++  const toggleExpand = useUploadStore((state) => state.toggleExpand);
++
++  return (
++    <ExpandableStatusBar
++      key={upload.id}
++      isExpanded={upload.isExpanded}
++      handleExpanded={() => toggleExpand(upload.id)}
++      title={
++        <>
++          <ListItemIcon sx={{ minWidth: "40px" }}>
++            {getIcon(upload.status)}
++          </ListItemIcon>
++          <ListItemText
++            primary={
++              <Typography variant="body2" sx={{ fontWeight: "bold" }}>
++                {upload.fileName}
++              </Typography>
++            }
++            secondary={
++              <Typography variant="body2" color="text.secondary">
++                {upload.status === "uploading"
++                  ? "上傳中..."
++                  : upload.status === "success"
++                    ? "上傳成功"
++                    : "上傳失敗"}
++              </Typography>
++            }
++          />
++          <RemoveUploadButton uploadId={upload.id} status={upload.status} />
++        </>
++      }
++      detail={
++        <UploadStatusDetail
++          upload={upload}
++          handleOpenDialog={handleOpenDialog}
++        />
++      }
++    />
++  );
++};
+diff --git a/src/components/DataTablesPage/UploadStatusPanel.tsx b/src/components/DataTablesPage/UploadStatusPanel.tsx
+index 590eb55..3e8395d 100644
+--- a/src/components/DataTablesPage/UploadStatusPanel.tsx
++++ b/src/components/DataTablesPage/UploadStatusPanel.tsx
+@@ -1,162 +1,16 @@
+ // src/components/DataTablesPage/UploadStatusPanel.tsx
+-import React, { useState, useCallback } from "react";
+-import {
+-  Box,
+-  Typography,
+-  List,
+-  ListItemText,
+-  LinearProgress,
+-  Paper,
+-  IconButton,
+-  AccordionDetails,
+-  Accordion,
+-  AccordionSummary,
+-  ListItemIcon,
+-  Dialog,
+-  DialogTitle,
+-  DialogContent,
+-  DialogActions,
+-  Button,
+-  Link,
+-  Snackbar,
+-} from "@mui/material";
+-import CheckCircleIcon from "@mui/icons-material/CheckCircle";
+-import ErrorIcon from "@mui/icons-material/Error";
+-import CloudUploadIcon from "@mui/icons-material/CloudUpload";
+-import CloseIcon from "@mui/icons-material/Close";
+-import ContentCopyIcon from "@mui/icons-material/ContentCopy";
++import React, { useState } from "react";
++import { Box, List } from "@mui/material";
+ 
+-import {
+-  useUploadStore,
+-  type FileUploadStatus,
+-} from "../../stores/uploadStore";
++import { useUploadStore } from "../../stores/uploadStore";
+ 
+-import { STANDARD_JSON_EXAMPLE } from "../../utils";
+-
+-// --- 標準格式對話框元件 ---
+-interface StandardFormatDialogProps {
+-  open: boolean;
+-  onClose: () => void;
+-}
+-
+-const StandardFormatDialog: React.FC<StandardFormatDialogProps> = ({
+-  open,
+-  onClose,
+-}) => {
+-  const [snackbarOpen, setSnackbarOpen] = useState(false);
+-
+-  const handleCopy = useCallback(() => {
+-    // 複製標準 JSON 範例到剪貼簿
+-    navigator.clipboard.writeText(STANDARD_JSON_EXAMPLE).then(() => {
+-      setSnackbarOpen(true);
+-    });
+-  }, []);
+-
+-  const handleSnackbarClose = (
+-    _event: React.SyntheticEvent | Event,
+-    reason?: string
+-  ) => {
+-    if (reason === "clickaway") {
+-      return;
+-    }
+-    setSnackbarOpen(false);
+-  };
+-
+-  return (
+-    <>
+-      <Dialog
+-        open={open}
+-        onClose={onClose}
+-        aria-labelledby="standard-format-dialog-title"
+-        maxWidth="md"
+-        fullWidth
+-      >
+-        <DialogTitle id="standard-format-dialog-title">
+-          標準 JSON 檔案格式範例
+-          <IconButton
+-            aria-label="close"
+-            onClick={onClose}
+-            sx={{
+-              position: "absolute",
+-              right: 8,
+-              top: 8,
+-              color: (theme) => theme.palette.grey[500],
+-            }}
+-          >
+-            <CloseIcon />
+-          </IconButton>
+-        </DialogTitle>
+-        <DialogContent dividers>
+-          <Typography gutterBottom variant="subtitle1">
+-            請確保您的 JSON 檔案符合以下格式規範：
+-          </Typography>
+-          <List dense sx={{ ml: 2, mb: 2 }}>
+-            <ListItemText primary="- 必須是陣列（[ ]）" />
+-            <ListItemText primary="- 陣列元素並須是非陣列的物件（{ }）" />
+-            <ListItemText primary="- 所有物件（資料列）都應有相同的鍵（欄位名稱）" />
+-          </List>
+-          <Box
+-            sx={{
+-              backgroundColor: "#f5f5f5",
+-              p: 2,
+-              borderRadius: 1,
+-              overflowX: "auto",
+-              position: "relative",
+-            }}
+-          >
+-            <IconButton
+-              aria-label="copy"
+-              onClick={handleCopy}
+-              size="small"
+-              sx={{
+-                position: "absolute",
+-                top: 8,
+-                right: 8,
+-                color: "text.secondary",
+-              }}
+-            >
+-              <ContentCopyIcon fontSize="small" />
+-            </IconButton>
+-            <pre style={{ margin: 0, whiteSpace: "pre-wrap" }}>
+-              <code>{STANDARD_JSON_EXAMPLE}</code>
+-            </pre>
+-          </Box>
+-        </DialogContent>
+-        <DialogActions>
+-          <Button onClick={onClose} color="primary" variant="contained">
+-            關閉
+-          </Button>
+-        </DialogActions>
+-      </Dialog>
+-      <Snackbar
+-        open={snackbarOpen}
+-        autoHideDuration={3000}
+-        onClose={handleSnackbarClose}
+-        message="標準 JSON 格式已複製！"
+-      />
+-    </>
+-  );
+-};
+-// --- UploadStatusPanel 元件 ---
+-
+-const getIcon = (status: FileUploadStatus["status"]) => {
+-  switch (status) {
+-    case "success":
+-      return <CheckCircleIcon color="success" sx={{ mr: 1 }} />;
+-    case "failed":
+-      return <ErrorIcon color="error" sx={{ mr: 1 }} />;
+-    case "uploading":
+-    default:
+-      return <CloudUploadIcon color="primary" sx={{ mr: 1 }} />;
+-  }
+-};
++import { UploadStatusBar } from "./UploadStatusBar";
++import { StandardFormatDialog } from "./StandardFormatDialog";
+ 
+ export const UploadStatusPanel: React.FC = () => {
+   const uploads = useUploadStore((state) => state.uploads);
+-  const removeUpload = useUploadStore((state) => state.removeUpload);
+-  const toggleExpand = useUploadStore((state) => state.toggleExpand);
+ 
+-  // 控制對話框的開關狀態
++  // 控制[標準格式對話框]的開關狀態
+   const [isDialogOpen, setIsDialogOpen] = useState(false);
+ 
+   const handleOpenDialog = (e: React.MouseEvent) => {
+@@ -181,95 +35,10 @@ export const UploadStatusPanel: React.FC = () => {
+       <StandardFormatDialog open={isDialogOpen} onClose={handleCloseDialog} />
+       <List dense sx={{ mt: 1 }}>
+         {uploads.map((upload) => (
+-          <Paper key={upload.id} elevation={1} sx={{ mb: 1 }}>
+-            <Accordion
+-              expanded={upload.isExpanded}
+-              onChange={() => toggleExpand(upload.id)}
+-              sx={{
+-                "&.MuiAccordion-root": {
+-                  boxShadow: "none",
+-                  "&::before": { display: "none" },
+-                },
+-              }}
+-            >
+-              <AccordionSummary
+-                aria-controls={`panel-${upload.id}-content`}
+-                id={`panel-${upload.id}-header`}
+-                sx={{
+-                  minHeight: "48px",
+-                  "&.Mui-expanded": { minHeight: "48px" },
+-                  "& .MuiAccordionSummary-content": {
+-                    alignItems: "center",
+-                    margin: "12px 0",
+-                    "&.Mui-expanded": { margin: "12px 0" },
+-                  },
+-                }}
+-              >
+-                <ListItemIcon sx={{ minWidth: "40px" }}>
+-                  {getIcon(upload.status)}
+-                </ListItemIcon>
+-                <ListItemText
+-                  primary={
+-                    <Typography variant="body2" sx={{ fontWeight: "bold" }}>
+-                      {upload.fileName}
+-                    </Typography>
+-                  }
+-                  secondary={
+-                    <Typography variant="body2" color="text.secondary">
+-                      {upload.status === "uploading"
+-                        ? "上傳中..."
+-                        : upload.status === "success"
+-                          ? "上傳成功"
+-                          : "上傳失敗"}
+-                    </Typography>
+-                  }
+-                />
+-                {(upload.status === "success" ||
+-                  upload.status === "failed") && (
+-                  <IconButton
+-                    edge="end"
+-                    aria-label="delete"
+-                    onClick={(e) => {
+-                      e.stopPropagation(); // 阻止事件冒泡到 AccordionSummary
+-                      removeUpload(upload.id);
+-                    }}
+-                    size="small"
+-                    sx={{ ml: 1 }}
+-                  >
+-                    <CloseIcon />
+-                  </IconButton>
+-                )}
+-              </AccordionSummary>
+-              <AccordionDetails>
+-                {upload.status === "uploading" && <LinearProgress />}
+-                {upload.status === "failed" && (
+-                  <Box
+-                    sx={{
+-                      mt: 1,
+-                      p: 1,
+-                      backgroundColor: "rgba(255, 0, 0, 0.05)",
+-                      borderRadius: 1,
+-                    }}
+-                  >
+-                    <Typography variant="body2" color="error">
+-                      錯誤原因: {upload.error}
+-                    </Typography>
+-                    {/* 檢查是否有 JSON 格式錯誤前綴，顯示連結 */}
+-                    {upload.error && upload.errorName === "ValidationError" && (
+-                      <Link
+-                        component="button"
+-                        variant="body2"
+-                        onClick={handleOpenDialog}
+-                        sx={{ mt: 1, display: "block" }}
+-                      >
+-                        檢視標準 JSON 格式範例
+-                      </Link>
+-                    )}
+-                  </Box>
+-                )}
+-              </AccordionDetails>
+-            </Accordion>
+-          </Paper>
++          <UploadStatusBar
++            fileuploadStatus={upload}
++            handleOpenDialog={handleOpenDialog}
++          />
+         ))}
+       </List>
+     </Box>
+diff --git a/src/components/DataTablesPage/uploadHelpers.tsx b/src/components/DataTablesPage/uploadHelpers.tsx
+new file mode 100644
+index 0000000..7fe9fdb
+--- /dev/null
++++ b/src/components/DataTablesPage/uploadHelpers.tsx
+@@ -0,0 +1,17 @@
++// src/components/DataTablesPage/uploadHelpers.tsx
++import type { FileUploadStatus } from "../../stores/uploadStore";
++import CheckCircleIcon from "@mui/icons-material/CheckCircle";
++import ErrorIcon from "@mui/icons-material/Error";
++import CloudUploadIcon from "@mui/icons-material/CloudUpload";
++
++export const getIcon = (status: FileUploadStatus["status"]) => {
++  switch (status) {
++    case "success":
++      return <CheckCircleIcon color="success" sx={{ mr: 1 }} />;
++    case "failed":
++      return <ErrorIcon color="error" sx={{ mr: 1 }} />;
++    case "uploading":
++    default:
++      return <CloudUploadIcon color="primary" sx={{ mr: 1 }} />;
++  }
++};
+diff --git a/src/components/common/ExpandableStatusBar.tsx b/src/components/common/ExpandableStatusBar.tsx
+new file mode 100644
+index 0000000..766d86f
+--- /dev/null
++++ b/src/components/common/ExpandableStatusBar.tsx
+@@ -0,0 +1,57 @@
++// src/components/common/ExpandableStatusBar.tsx
++import React from "react";
++import {
++  Paper,
++  AccordionDetails,
++  Accordion,
++  AccordionSummary,
++} from "@mui/material";
++
++interface Props {
++  key: React.Key;
++  isExpanded?: boolean;
++  handleExpanded?:
++    | ((event: React.SyntheticEvent, expanded: boolean) => void)
++    | undefined;
++  title: React.ReactElement;
++  detail: React.ReactElement;
++}
++export const ExpandableStatusBar: React.FC<Props> = ({
++  key,
++  isExpanded,
++  handleExpanded,
++  title,
++  detail,
++}) => {
++  return (
++    <Paper key={key} elevation={1} sx={{ mb: 1 }}>
++      <Accordion
++        expanded={isExpanded}
++        onChange={handleExpanded}
++        sx={{
++          "&.MuiAccordion-root": {
++            boxShadow: "none",
++            "&::before": { display: "none" },
++          },
++        }}
++      >
++        <AccordionSummary
++          aria-controls={`panel-${key}-content`}
++          id={`panel-${key}-header`}
++          sx={{
++            minHeight: "48px",
++            "&.Mui-expanded": { minHeight: "48px" },
++            "& .MuiAccordionSummary-content": {
++              alignItems: "center",
++              margin: "12px 0",
++              "&.Mui-expanded": { margin: "12px 0" },
++            },
++          }}
++        >
++          {title}
++        </AccordionSummary>
++        <AccordionDetails>{detail}</AccordionDetails>
++      </Accordion>
++    </Paper>
++  );
++};
+```
+
+## Copilot 回答 上傳狀態面板抽象化-進一步抽象
+非常好的問題。
+這份重構（拆解）整體上**是合理且值得推薦的**，屬於一個中大型 React 專案中典型、成熟的「關注點分離（Separation of Concerns）」範例。
+我會先用專業前端工程師角度逐層分析其必要性與改進空間：
+
+---
+
+### 🧩 一、整體結構調整概觀
+
+原始的 `UploadStatusPanel.tsx`：
+
+* 混合了三種責任：
+
+  1. **上傳狀態渲染邏輯**
+  2. **標準 JSON 對話框邏輯**
+  3. **UI 細節（Accordion、Icon、錯誤訊息等）**
+* 文件長度高達 ~160 行，責任過於集中，測試性差、重用性差。
+
+現在的拆解：
+
+* `UploadStatusPanel` ➜ 僅負責「容器與資料來源」
+* `UploadStatusBar` ➜ 負責「單一項目的狀態呈現」
+* `StandardFormatDialog` ➜ 負責「標準格式對話框」
+* `uploadHelpers` ➜ 集中 icon 或通用 render 函式
+* `ExpandableStatusBar` ➜ 泛用的「可展開區塊」元件，可重複使用於非上傳場景
+
+✅ **這種拆解是合理且必要的，因為：**
+
+* 降低單一檔案複雜度，利於測試與維護
+* 各子元件可重用（例如未來資料導入模組）
+* 清晰的責任邊界符合 React 組件設計原則（Container / Presentational pattern）
+* 組件間依賴方向乾淨 (`UploadStatusPanel` ➜ `UploadStatusBar` ➜ `ExpandableStatusBar`)
+
+---
+
+### ⚙️ 二、各模組分析
+
+#### 1. `StandardFormatDialog.tsx`
+
+**✅ 拆解必要**
+
+* 原先與上傳狀態無強耦合，只是「錯誤時彈出的輔助說明」。
+* 拆成獨立 dialog 可重用於其他模組（例如資料驗證模組）。
+* 程式獨立管理內部 snackbar 狀態，乾淨。
+
+**🔧 可微調建議**
+
+* `handleCopy` 應考慮 `await navigator.clipboard.writeText()` 加上錯誤處理（clipboard 失敗時提示）。
+* `Dialog` + `Snackbar` 可以再抽成 Hook（例如 `useClipboardCopy`），以避免多處重複使用時邏輯重疊。
+
+---
+
+#### 2. `UploadStatusBar.tsx`
+
+**✅ 拆解合理**
+
+* 將「每筆上傳任務」抽出，符合 atomic design 的 *Molecule*。
+* 子元件拆分得當（`RemoveUploadButton`, `UploadStatusDetail`），提高可測試性。
+* 對 `UploadStatusPanel` 減負：Panel 不再需要知道「怎麼渲染失敗」、「怎麼刪除 upload」。
+
+**🔧 改進建議**
+
+* `RemoveUploadButton`：建議將 `status` 條件交由外層判斷後才渲染此元件（避免元件同時擔任邏輯 + 呈現責任）。
+* `UploadStatusDetail`：
+
+  * 可以把 `"ValidationError"` 這類錯誤名稱常數集中於 `constants/errorTypes.ts`，減少 magic string。
+  * 若未來有更多錯誤類型，可改為對應表（map）以支援動態顯示提示連結。
+
+---
+
+#### 3. `ExpandableStatusBar.tsx`
+
+**✅ 很好的通用抽象**
+
+* 從原 `Accordion` 結構抽離，使 layout 邏輯與內容分離。
+* 可直接複用於其他模組，如「任務列表」、「匯出歷史」、「通知列」。
+
+**⚠️ 小問題**
+
+* Props 中 `key` 不建議出現在 prop 定義裡：
+  React 的 `key` 是特殊屬性，不會傳入子元件。這裡若需要唯一識別，建議用 `id: string | number`。
+
+  ```tsx
+  interface Props {
+    id: string;
+    isExpanded?: boolean;
+    handleExpanded?: (event: React.SyntheticEvent, expanded: boolean) => void;
+    title: React.ReactElement;
+    detail: React.ReactElement;
+  }
+  ```
+
+  然後在最外層呼叫 `<ExpandableStatusBar key={upload.id} id={upload.id} ... />`
+
+---
+
+#### 4. `uploadHelpers.tsx`
+
+**✅ 非常合理**
+
+* Icon 呈現本來與主邏輯無關，集中於 helper 可減少重複程式碼。
+* 若未來有更多狀態（paused, retrying 等）可以在此擴充。
+
+---
+
+### 🧠 三、從架構角度評估是否「必要」
+
+| 拆解檔案               | 拆解是否必要 | 理由                                |
+| ---------------------- | ------------ | ----------------------------------- |
+| `StandardFormatDialog` | ✅ 必要       | 獨立職責，UI 重用性高               |
+| `UploadStatusBar`      | ✅ 必要       | 提升可測試性，明確單一任務渲染責任  |
+| `uploadHelpers`        | ⚙️ 適度       | 適合提取通用樣式／icon 函數         |
+| `ExpandableStatusBar`  | ✅ 非常推薦   | 提供良好 pattern，鼓勵一致的展開 UI |
+
+---
+
+### 💡 四、更好的進一步拆解建議（若要更精緻）
+
+1. **將狀態邏輯抽成 Hook**
+
+   ```ts
+   // useUploadStatus.ts
+   export const useUploadStatus = (upload: FileUploadStatus) => {
+     const { removeUpload, toggleExpand } = useUploadStore();
+     const isRemovable = upload.status === "success" || upload.status === "failed";
+     const statusLabel = upload.status === "uploading" ? "上傳中..." : upload.status === "success" ? "上傳成功" : "上傳失敗";
+     return { isRemovable, statusLabel, removeUpload, toggleExpand };
+   };
+   ```
+
+   → `UploadStatusBar` 可變得更純粹，無需關心 store 細節。
+
+2. **Dialog 彈出可考慮 context 共享**
+   若未來多個錯誤來源都會開 `StandardFormatDialog`，可建立一個 `DialogContext` 統一管理彈窗。
+
+3. **狀態樣式可配置化**
+   把 `"rgba(255, 0, 0, 0.05)"` 等樣式集中在 theme tokens 或 constants。
+
+---
+
+### ✅ 最終結論
+
+| 面向       | 評價                                     |
+| ---------- | ---------------------------------------- |
+| 可維護性   | ★★★★★                                    |
+| 可重用性   | ★★★★☆                                    |
+| 拆解粒度   | 適中（可再微調 key/id 部分）             |
+| 技術合理性 | 完全符合 React 與 MUI 最佳實踐           |
+| 推薦程度   | **強烈推薦**（清晰、模組化、未來可擴充） |
+
+---
+
+若要一句話總結：
+
+> 💬 「這次拆解乾淨俐落，成功將 UI、邏輯、輔助元件解耦。唯一的小瑕疵是 `ExpandableStatusBar` 的 key 傳遞方式與 clipboard 錯誤處理，整體屬於非常成熟的模組化重構。」
+
+
+## Copilot 提問 
+## Copilot 回答 

--- a/src/components/DataTablesPage/StandardFormatDialog.tsx
+++ b/src/components/DataTablesPage/StandardFormatDialog.tsx
@@ -1,0 +1,136 @@
+// src/components/DataTablesPage/StandardFormatDialog.tsx
+import React, { useState, useCallback } from "react";
+import {
+  Box,
+  Typography,
+  List,
+  ListItemText,
+  IconButton,
+  Dialog,
+  DialogTitle,
+  DialogContent,
+  DialogActions,
+  Button,
+  Snackbar,
+} from "@mui/material";
+import CloseIcon from "@mui/icons-material/Close";
+import ContentCopyIcon from "@mui/icons-material/ContentCopy";
+
+import { STANDARD_JSON_EXAMPLE } from "../../utils";
+
+interface StandardFormatDialogProps {
+  open: boolean;
+  onClose: () => void;
+}
+
+export const StandardFormatDialog: React.FC<StandardFormatDialogProps> = ({
+  open,
+  onClose,
+}) => {
+  const [snackbarOpen, setSnackbarOpen] = useState(false);
+  const [copySuccess, setCopySuccess] = useState(true);
+
+  const handleCopy = useCallback(() => {
+    // 複製標準 JSON 範例到剪貼簿
+    navigator.clipboard
+      .writeText(STANDARD_JSON_EXAMPLE)
+      .then(() => {
+        setCopySuccess(true);
+        setSnackbarOpen(true);
+      })
+      .catch((err) => {
+        console.error("Could not copy text: ", err);
+        setCopySuccess(false);
+        setSnackbarOpen(true);
+      });
+  }, []);
+
+  const handleSnackbarClose = (
+    _event: React.SyntheticEvent | Event,
+    reason?: string
+  ) => {
+    if (reason === "clickaway") {
+      return;
+    }
+    setSnackbarOpen(false);
+  };
+
+  return (
+    <>
+      <Dialog
+        open={open}
+        onClose={onClose}
+        aria-labelledby="standard-format-dialog-title"
+        maxWidth="md"
+        fullWidth
+      >
+        <DialogTitle id="standard-format-dialog-title">
+          標準 JSON 檔案格式範例
+          <IconButton
+            aria-label="close"
+            onClick={onClose}
+            sx={{
+              position: "absolute",
+              right: 8,
+              top: 8,
+              color: (theme) => theme.palette.grey[500],
+            }}
+          >
+            <CloseIcon />
+          </IconButton>
+        </DialogTitle>
+        <DialogContent dividers>
+          <Typography gutterBottom variant="subtitle1">
+            請確保您的 JSON 檔案符合以下格式規範：
+          </Typography>
+          <List dense sx={{ ml: 2, mb: 2 }}>
+            <ListItemText primary="- 必須是陣列（[ ]）" />
+            <ListItemText primary="- 陣列元素並須是非陣列的物件（{ }）" />
+            <ListItemText primary="- 所有物件（資料列）都應有相同的鍵（欄位名稱）" />
+          </List>
+          <Box
+            sx={{
+              backgroundColor: "#f5f5f5",
+              p: 2,
+              borderRadius: 1,
+              overflowX: "auto",
+              position: "relative",
+            }}
+          >
+            <IconButton
+              aria-label="copy"
+              onClick={handleCopy}
+              size="small"
+              sx={{
+                position: "absolute",
+                top: 8,
+                right: 8,
+                color: "text.secondary",
+              }}
+            >
+              <ContentCopyIcon fontSize="small" />
+            </IconButton>
+            <pre style={{ margin: 0, whiteSpace: "pre-wrap" }}>
+              <code>{STANDARD_JSON_EXAMPLE}</code>
+            </pre>
+          </Box>
+        </DialogContent>
+        <DialogActions>
+          <Button onClick={onClose} color="primary" variant="contained">
+            關閉
+          </Button>
+        </DialogActions>
+      </Dialog>
+      <Snackbar
+        open={snackbarOpen}
+        autoHideDuration={3000}
+        onClose={handleSnackbarClose}
+        message={
+          copySuccess
+            ? "標準 JSON 格式已複製！"
+            : "複製標準 JSON 格式失敗！請手動複製！"
+        }
+      />
+    </>
+  );
+};

--- a/src/components/DataTablesPage/UploadStatusBar.tsx
+++ b/src/components/DataTablesPage/UploadStatusBar.tsx
@@ -1,0 +1,137 @@
+// src/components/DataTablesPage/UploadStatusBar.tsx
+import React from "react";
+import {
+  Box,
+  Typography,
+  ListItemText,
+  LinearProgress,
+  IconButton,
+  ListItemIcon,
+  Link,
+} from "@mui/material";
+import CloseIcon from "@mui/icons-material/Close";
+
+import {
+  useUploadStore,
+  type FileUploadStatus,
+} from "../../stores/uploadStore";
+
+import { ExpandableStatusBar } from "../common/ExpandableStatusBar";
+import { getIcon } from "./uploadHelpers";
+import { VALIDATION_ERROR } from "../../constants";
+
+interface RemoveButtonProps {
+  uploadId: string;
+}
+
+const RemoveUploadButton: React.FC<RemoveButtonProps> = ({ uploadId }) => {
+  // 從 store 中獲取刪除動作
+  const removeUpload = useUploadStore((state) => state.removeUpload);
+
+  return (
+    <IconButton
+      edge="end"
+      aria-label="delete"
+      onClick={(e) => {
+        e.stopPropagation(); // 關鍵：阻止事件冒泡
+        removeUpload(uploadId);
+      }}
+      size="small"
+      sx={{ ml: 1 }}
+    >
+      <CloseIcon />
+    </IconButton>
+  );
+};
+
+const UploadStatusDetail: React.FC<{
+  upload: FileUploadStatus;
+  handleOpenDialog: (e: React.MouseEvent) => void;
+}> = ({ upload, handleOpenDialog }) => {
+  if (upload.status === "uploading") {
+    return <LinearProgress />;
+  }
+
+  if (upload.status === "failed") {
+    return (
+      <Box
+        sx={{
+          mt: 1,
+          p: 1,
+          backgroundColor: "rgba(255, 0, 0, 0.05)",
+          borderRadius: 1,
+        }}
+      >
+        <Typography variant="body2" color="error">
+          錯誤原因: {upload.error}
+        </Typography>
+        {/* 檢查是否有 JSON 格式錯誤前綴，顯示連結 */}
+        {upload.error && upload.errorName === VALIDATION_ERROR && (
+          <Link
+            component="button"
+            variant="body2"
+            onClick={handleOpenDialog}
+            sx={{ mt: 1, display: "block" }}
+          >
+            檢視標準 JSON 格式範例
+          </Link>
+        )}
+      </Box>
+    );
+  }
+  return null; // 或其他成功/閒置狀態的內容
+};
+
+// --- UploadStatusBar 元件 ---
+
+interface UploadStatusBarProps {
+  fileuploadStatus: FileUploadStatus;
+  handleOpenDialog: (e: React.MouseEvent) => void;
+}
+
+export const UploadStatusBar: React.FC<UploadStatusBarProps> = ({
+  fileuploadStatus: upload,
+  handleOpenDialog,
+}) => {
+  const toggleExpand = useUploadStore((state) => state.toggleExpand);
+
+  return (
+    <ExpandableStatusBar
+      id={upload.id}
+      isExpanded={upload.isExpanded}
+      handleExpanded={() => toggleExpand(upload.id)}
+      title={
+        <>
+          <ListItemIcon sx={{ minWidth: "40px" }}>
+            {getIcon(upload.status)}
+          </ListItemIcon>
+          <ListItemText
+            primary={
+              <Typography variant="body2" sx={{ fontWeight: "bold" }}>
+                {upload.fileName}
+              </Typography>
+            }
+            secondary={
+              <Typography variant="body2" color="text.secondary">
+                {upload.status === "uploading"
+                  ? "上傳中..."
+                  : upload.status === "success"
+                    ? "上傳成功"
+                    : "上傳失敗"}
+              </Typography>
+            }
+          />
+          {upload.status !== "success" && upload.status !== "failed" ? (
+            <RemoveUploadButton uploadId={upload.id} />
+          ) : null}
+        </>
+      }
+      detail={
+        <UploadStatusDetail
+          upload={upload}
+          handleOpenDialog={handleOpenDialog}
+        />
+      }
+    />
+  );
+};

--- a/src/components/DataTablesPage/UploadStatusPanel.tsx
+++ b/src/components/DataTablesPage/UploadStatusPanel.tsx
@@ -1,162 +1,16 @@
 // src/components/DataTablesPage/UploadStatusPanel.tsx
-import React, { useState, useCallback } from "react";
-import {
-  Box,
-  Typography,
-  List,
-  ListItemText,
-  LinearProgress,
-  Paper,
-  IconButton,
-  AccordionDetails,
-  Accordion,
-  AccordionSummary,
-  ListItemIcon,
-  Dialog,
-  DialogTitle,
-  DialogContent,
-  DialogActions,
-  Button,
-  Link,
-  Snackbar,
-} from "@mui/material";
-import CheckCircleIcon from "@mui/icons-material/CheckCircle";
-import ErrorIcon from "@mui/icons-material/Error";
-import CloudUploadIcon from "@mui/icons-material/CloudUpload";
-import CloseIcon from "@mui/icons-material/Close";
-import ContentCopyIcon from "@mui/icons-material/ContentCopy";
+import React, { useState } from "react";
+import { Box, List } from "@mui/material";
 
-import {
-  useUploadStore,
-  type FileUploadStatus,
-} from "../../stores/uploadStore";
+import { useUploadStore } from "../../stores/uploadStore";
 
-import { STANDARD_JSON_EXAMPLE } from "../../utils";
-
-// --- 標準格式對話框元件 ---
-interface StandardFormatDialogProps {
-  open: boolean;
-  onClose: () => void;
-}
-
-const StandardFormatDialog: React.FC<StandardFormatDialogProps> = ({
-  open,
-  onClose,
-}) => {
-  const [snackbarOpen, setSnackbarOpen] = useState(false);
-
-  const handleCopy = useCallback(() => {
-    // 複製標準 JSON 範例到剪貼簿
-    navigator.clipboard.writeText(STANDARD_JSON_EXAMPLE).then(() => {
-      setSnackbarOpen(true);
-    });
-  }, []);
-
-  const handleSnackbarClose = (
-    _event: React.SyntheticEvent | Event,
-    reason?: string
-  ) => {
-    if (reason === "clickaway") {
-      return;
-    }
-    setSnackbarOpen(false);
-  };
-
-  return (
-    <>
-      <Dialog
-        open={open}
-        onClose={onClose}
-        aria-labelledby="standard-format-dialog-title"
-        maxWidth="md"
-        fullWidth
-      >
-        <DialogTitle id="standard-format-dialog-title">
-          標準 JSON 檔案格式範例
-          <IconButton
-            aria-label="close"
-            onClick={onClose}
-            sx={{
-              position: "absolute",
-              right: 8,
-              top: 8,
-              color: (theme) => theme.palette.grey[500],
-            }}
-          >
-            <CloseIcon />
-          </IconButton>
-        </DialogTitle>
-        <DialogContent dividers>
-          <Typography gutterBottom variant="subtitle1">
-            請確保您的 JSON 檔案符合以下格式規範：
-          </Typography>
-          <List dense sx={{ ml: 2, mb: 2 }}>
-            <ListItemText primary="- 必須是陣列（[ ]）" />
-            <ListItemText primary="- 陣列元素並須是非陣列的物件（{ }）" />
-            <ListItemText primary="- 所有物件（資料列）都應有相同的鍵（欄位名稱）" />
-          </List>
-          <Box
-            sx={{
-              backgroundColor: "#f5f5f5",
-              p: 2,
-              borderRadius: 1,
-              overflowX: "auto",
-              position: "relative",
-            }}
-          >
-            <IconButton
-              aria-label="copy"
-              onClick={handleCopy}
-              size="small"
-              sx={{
-                position: "absolute",
-                top: 8,
-                right: 8,
-                color: "text.secondary",
-              }}
-            >
-              <ContentCopyIcon fontSize="small" />
-            </IconButton>
-            <pre style={{ margin: 0, whiteSpace: "pre-wrap" }}>
-              <code>{STANDARD_JSON_EXAMPLE}</code>
-            </pre>
-          </Box>
-        </DialogContent>
-        <DialogActions>
-          <Button onClick={onClose} color="primary" variant="contained">
-            關閉
-          </Button>
-        </DialogActions>
-      </Dialog>
-      <Snackbar
-        open={snackbarOpen}
-        autoHideDuration={3000}
-        onClose={handleSnackbarClose}
-        message="標準 JSON 格式已複製！"
-      />
-    </>
-  );
-};
-// --- UploadStatusPanel 元件 ---
-
-const getIcon = (status: FileUploadStatus["status"]) => {
-  switch (status) {
-    case "success":
-      return <CheckCircleIcon color="success" sx={{ mr: 1 }} />;
-    case "failed":
-      return <ErrorIcon color="error" sx={{ mr: 1 }} />;
-    case "uploading":
-    default:
-      return <CloudUploadIcon color="primary" sx={{ mr: 1 }} />;
-  }
-};
+import { UploadStatusBar } from "./UploadStatusBar";
+import { StandardFormatDialog } from "./StandardFormatDialog";
 
 export const UploadStatusPanel: React.FC = () => {
   const uploads = useUploadStore((state) => state.uploads);
-  const removeUpload = useUploadStore((state) => state.removeUpload);
-  const toggleExpand = useUploadStore((state) => state.toggleExpand);
 
-  // 控制對話框的開關狀態
+  // 控制[標準格式對話框]的開關狀態
   const [isDialogOpen, setIsDialogOpen] = useState(false);
 
   const handleOpenDialog = (e: React.MouseEvent) => {
@@ -181,95 +35,10 @@ export const UploadStatusPanel: React.FC = () => {
       <StandardFormatDialog open={isDialogOpen} onClose={handleCloseDialog} />
       <List dense sx={{ mt: 1 }}>
         {uploads.map((upload) => (
-          <Paper key={upload.id} elevation={1} sx={{ mb: 1 }}>
-            <Accordion
-              expanded={upload.isExpanded}
-              onChange={() => toggleExpand(upload.id)}
-              sx={{
-                "&.MuiAccordion-root": {
-                  boxShadow: "none",
-                  "&::before": { display: "none" },
-                },
-              }}
-            >
-              <AccordionSummary
-                aria-controls={`panel-${upload.id}-content`}
-                id={`panel-${upload.id}-header`}
-                sx={{
-                  minHeight: "48px",
-                  "&.Mui-expanded": { minHeight: "48px" },
-                  "& .MuiAccordionSummary-content": {
-                    alignItems: "center",
-                    margin: "12px 0",
-                    "&.Mui-expanded": { margin: "12px 0" },
-                  },
-                }}
-              >
-                <ListItemIcon sx={{ minWidth: "40px" }}>
-                  {getIcon(upload.status)}
-                </ListItemIcon>
-                <ListItemText
-                  primary={
-                    <Typography variant="body2" sx={{ fontWeight: "bold" }}>
-                      {upload.fileName}
-                    </Typography>
-                  }
-                  secondary={
-                    <Typography variant="body2" color="text.secondary">
-                      {upload.status === "uploading"
-                        ? "上傳中..."
-                        : upload.status === "success"
-                          ? "上傳成功"
-                          : "上傳失敗"}
-                    </Typography>
-                  }
-                />
-                {(upload.status === "success" ||
-                  upload.status === "failed") && (
-                  <IconButton
-                    edge="end"
-                    aria-label="delete"
-                    onClick={(e) => {
-                      e.stopPropagation(); // 阻止事件冒泡到 AccordionSummary
-                      removeUpload(upload.id);
-                    }}
-                    size="small"
-                    sx={{ ml: 1 }}
-                  >
-                    <CloseIcon />
-                  </IconButton>
-                )}
-              </AccordionSummary>
-              <AccordionDetails>
-                {upload.status === "uploading" && <LinearProgress />}
-                {upload.status === "failed" && (
-                  <Box
-                    sx={{
-                      mt: 1,
-                      p: 1,
-                      backgroundColor: "rgba(255, 0, 0, 0.05)",
-                      borderRadius: 1,
-                    }}
-                  >
-                    <Typography variant="body2" color="error">
-                      錯誤原因: {upload.error}
-                    </Typography>
-                    {/* 檢查是否有 JSON 格式錯誤前綴，顯示連結 */}
-                    {upload.error && upload.errorName === "ValidationError" && (
-                      <Link
-                        component="button"
-                        variant="body2"
-                        onClick={handleOpenDialog}
-                        sx={{ mt: 1, display: "block" }}
-                      >
-                        檢視標準 JSON 格式範例
-                      </Link>
-                    )}
-                  </Box>
-                )}
-              </AccordionDetails>
-            </Accordion>
-          </Paper>
+          <UploadStatusBar
+            fileuploadStatus={upload}
+            handleOpenDialog={handleOpenDialog}
+          />
         ))}
       </List>
     </Box>

--- a/src/components/DataTablesPage/uploadHelpers.tsx
+++ b/src/components/DataTablesPage/uploadHelpers.tsx
@@ -1,0 +1,17 @@
+// src/components/DataTablesPage/uploadHelpers.tsx
+import type { FileUploadStatus } from "../../stores/uploadStore";
+import CheckCircleIcon from "@mui/icons-material/CheckCircle";
+import ErrorIcon from "@mui/icons-material/Error";
+import CloudUploadIcon from "@mui/icons-material/CloudUpload";
+
+export const getIcon = (status: FileUploadStatus["status"]) => {
+  switch (status) {
+    case "success":
+      return <CheckCircleIcon color="success" sx={{ mr: 1 }} />;
+    case "failed":
+      return <ErrorIcon color="error" sx={{ mr: 1 }} />;
+    case "uploading":
+    default:
+      return <CloudUploadIcon color="primary" sx={{ mr: 1 }} />;
+  }
+};

--- a/src/components/common/ExpandableStatusBar.tsx
+++ b/src/components/common/ExpandableStatusBar.tsx
@@ -1,0 +1,55 @@
+// src/components/common/ExpandableStatusBar.tsx
+import React from "react";
+import {
+  Paper,
+  AccordionDetails,
+  Accordion,
+  AccordionSummary,
+} from "@mui/material";
+
+interface Props {
+  id: React.Key;
+  isExpanded?: boolean;
+  handleExpanded?: (event: React.SyntheticEvent, expanded: boolean) => void;
+  title: React.ReactElement;
+  detail: React.ReactElement;
+}
+export const ExpandableStatusBar: React.FC<Props> = ({
+  id: key,
+  isExpanded,
+  handleExpanded,
+  title,
+  detail,
+}) => {
+  return (
+    <Paper key={key} elevation={1} sx={{ mb: 1 }}>
+      <Accordion
+        expanded={isExpanded}
+        onChange={handleExpanded}
+        sx={{
+          "&.MuiAccordion-root": {
+            boxShadow: "none",
+            "&::before": { display: "none" },
+          },
+        }}
+      >
+        <AccordionSummary
+          aria-controls={`panel-${key}-content`}
+          id={`panel-${key}-header`}
+          sx={{
+            minHeight: "48px",
+            "&.Mui-expanded": { minHeight: "48px" },
+            "& .MuiAccordionSummary-content": {
+              alignItems: "center",
+              margin: "12px 0",
+              "&.Mui-expanded": { margin: "12px 0" },
+            },
+          }}
+        >
+          {title}
+        </AccordionSummary>
+        <AccordionDetails>{detail}</AccordionDetails>
+      </Accordion>
+    </Paper>
+  );
+};

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -1,3 +1,5 @@
 export const SUPPORTED_FILE_TYPES = ["application/json", "text/csv"];
 
 export const MAX_FILE_SIZE = 10 * 1024 * 1024; // 10MB
+
+export const VALIDATION_ERROR = "ValidationError";

--- a/src/types.tsx
+++ b/src/types.tsx
@@ -1,5 +1,6 @@
 // src/types.tsx
 import type { TableId } from "shared/types/dataTable";
+import { VALIDATION_ERROR } from "./constants";
 
 export interface TocItem {
   label: string;
@@ -44,6 +45,6 @@ export type FileConflictAction = "rename" | "replace" | "skip";
 export class ValidationError extends Error {
   constructor(message: string) {
     super(message);
-    this.name = "ValidationError";
+    this.name = VALIDATION_ERROR;
   }
 }


### PR DESCRIPTION
## 📘 Summary / 摘要

This PR refactors the upload status panel into smaller, reusable components to improve readability, maintainability, and future scalability.
本 PR 將上傳狀態面板重構為可重用的獨立組件，提升程式可讀性、維護性與擴充性。

---

## 🏗️ Major Changes / 主要變更

### ✳️ Components

* **`UploadStatusBar`** → Handles single upload status item (icons, progress, actions).
  **單筆上傳列**：顯示圖示、進度條與刪除按鈕。
* **`ExpandableStatusBar`** → Generic collapsible container for reusable UI.
  **通用展開容器**：可重用的展開／收合元件。
* **`StandardFormatDialog`** → Shows sample JSON format with copy function.
  **標準格式對話框**：展示標準 JSON 格式並支援複製。
* **`uploadHelpers.tsx`** → Centralizes helper logic such as `getIcon()`.
  **輔助函式**：集中上傳狀態邏輯（如圖示選擇）。

### 🧹 Simplified Structure

* **`UploadStatusPanel.tsx`** rewritten to use new modular components.
  **原面板精簡化**，以組合方式整合新元件。

### ⚙️ Constants

* Added `VALIDATION_ERROR` constant in `src/types.tsx`.
* Unified all error naming for consistency.
  → 避免重複字串硬編碼，維護更一致。

---

## ✅ Testing / 測試重點

* [ ] Uploading multiple files still updates status correctly
* [ ] Error messages display correctly in `UploadStatusBar`
* [ ] Expand/collapse works smoothly
* [ ] “View Standard Format” dialog opens and copies properly
* [ ] No regression in existing upload flow

---

## 💡 Motivation / 動機

The previous `UploadStatusPanel` component was overly large and tightly coupled.
By splitting it into smaller parts, it’s now easier to maintain, extend, and test.

原先的 `UploadStatusPanel` 過於龐大、耦合度高。
透過組件化重構，改善程式可維護性、擴充性與測試性。
