### PR TITLE
**refactor: abstract DataTableList into reusable GenericListView and actions components** （重構：將 DataTableList 抽象化為可重用的 GenericListView 與操作組件）

### DIFF
--- a/src/components/DataTablesPage/DataTableList.tsx
+++ b/src/components/DataTablesPage/DataTableList.tsx
@@ -1,28 +1,10 @@
 // src/components/DataTablesPage/DataTableList.tsx
-import { useState } from "react";
 import { useNavigate } from "react-router-dom";
-import {
-  Box,
-  Card,
-  CardContent,
-  Typography,
-  Grid,
-  IconButton,
-  Menu,
-  MenuItem,
-  Table,
-  TableBody,
-  TableCell,
-  TableContainer,
-  TableHead,
-  TableRow,
-  Paper,
-  Link,
-} from "@mui/material";
-import MoreVertIcon from "@mui/icons-material/MoreVert";
+import { Box, Typography } from "@mui/material";
 import type { DataTableInfo, TableId } from "shared/types/dataTable";
 import type { EditTableNavigateState } from "../../types";
-import { DeleteWarningDialog } from "../common/DeleteWarningDialog";
+import { GenericListView, type GenericItem } from "../common/GenericListView";
+import { GenericItemActions } from "../common/GenericItemActions";
 
 interface Props {
   dataTables: DataTableInfo[];
@@ -36,15 +18,9 @@ export const DataTableList = ({
   viewMode,
   refreshTableInfos,
 }: Props) => {
-  const [anchorEl, setAnchorEl] = useState<null | HTMLElement>(null);
-  const [selectedTableId, setSelectedTableId] = useState<TableId | null>(null);
-  const [openDialog, setOpenDialog] = useState(false);
   const navigate = useNavigate();
 
-  const handleTableClick = (
-    _event: React.MouseEvent<HTMLElement>,
-    tableId: TableId
-  ) => {
+  const handleTableClick = (tableId: TableId) => {
     console.log(`點擊了表格 ${tableId}`);
     const state: EditTableNavigateState = {
       editorMode: "edit",
@@ -55,123 +31,23 @@ export const DataTableList = ({
     });
   };
 
-  const handleMenuClick = (
-    event: React.MouseEvent<HTMLElement>,
-    tableId: TableId
-  ) => {
-    setAnchorEl(event.currentTarget);
-    setSelectedTableId(tableId);
+  const handleAction = (action: string, id: TableId) => {
+    console.log(`對表格 ${id} 執行操作: ${action}`);
+    if (action === "delete") {
+      window.api.deleteTable(id);
+      refreshTableInfos();
+    }
   };
 
-  const handleMenuClose = () => {
-    setAnchorEl(null);
-    setSelectedTableId(null);
-  };
-
-  const handleAction = (action: string) => {
-    console.log(`對表格 ${selectedTableId} 執行操作: ${action}`);
-    handleMenuClose();
-  };
-
-  const closeDeleteDialog = () => {
-    setOpenDialog(false);
-    handleMenuClose();
-  };
-  const openDeleteDialog = () => {
-    setOpenDialog(true);
-    setAnchorEl(null);
-  };
-  const handleConfirmDelete = () => {
-    console.log(`刪除表格 ${selectedTableId}`);
-    window.api.deleteTable(selectedTableId!);
-    setOpenDialog(false);
-    handleMenuClose();
-    refreshTableInfos();
-  };
-
-  // 渲染列表的 Helper 函式
-  const renderList = () => (
-    <TableContainer component={Paper}>
-      <Table>
-        <TableHead>
-          <TableRow>
-            <TableCell>表格名稱</TableCell>
-            <TableCell>上傳日期</TableCell>
-            <TableCell>檔案大小</TableCell>
-            <TableCell align="right">操作</TableCell>
-          </TableRow>
-        </TableHead>
-        <TableBody>
-          {dataTables.map((table) => (
-            <TableRow key={table.id}>
-              <TableCell>
-                <Link onClick={(e) => handleTableClick(e, table.id)}>
-                  {table.name}
-                </Link>
-              </TableCell>
-              <TableCell>{table.updated_at}</TableCell>
-              <TableCell>{table.fileSize}</TableCell>
-              <TableCell align="right">
-                <IconButton
-                  aria-label="more"
-                  onClick={(e) => handleMenuClick(e, table.id)}
-                >
-                  <MoreVertIcon />
-                </IconButton>
-              </TableCell>
-            </TableRow>
-          ))}
-        </TableBody>
-      </Table>
-    </TableContainer>
-  );
-
-  // 渲染卡片的 Helper 函式
-  const renderCards = () => (
-    <Grid container spacing={3}>
-      {dataTables.length > 0 ? (
-        dataTables.map((table) => (
-          <Grid size={{ xs: 12, sm: 6, md: 4 }} key={table.id}>
-            <Card variant="outlined">
-              <CardContent>
-                <Box
-                  sx={{
-                    display: "flex",
-                    justifyContent: "space-between",
-                    alignItems: "center",
-                  }}
-                >
-                  <Typography variant="h6" component="div">
-                    <Link onClick={(e) => handleTableClick(e, table.id)}>
-                      {table.name}
-                    </Link>
-                  </Typography>
-                  <IconButton
-                    aria-label="more"
-                    onClick={(e) => handleMenuClick(e, table.id)}
-                  >
-                    <MoreVertIcon />
-                  </IconButton>
-                </Box>
-                <Typography variant="body2" color="text.secondary">
-                  上傳日期: {table.updated_at}
-                </Typography>
-                <Typography variant="body2" color="text.secondary">
-                  檔案大小: {table.fileSize}
-                </Typography>
-              </CardContent>
-            </Card>
-          </Grid>
-        ))
-      ) : (
-        <Grid size={{ xs: 12 }}>
-          <Typography variant="h6" color="text.secondary" align="center">
-            沒有找到符合條件的資料表格。
-          </Typography>
-        </Grid>
-      )}
-    </Grid>
-  );
+  // 將 DataTableInfo 轉換成 GenericItem
+  const genericItems: GenericItem[] = dataTables.map((table) => ({
+    id: table.id,
+    title: table.name,
+    updated_at: table.updated_at,
+    metadata: {
+      檔案大小: table.fileSize,
+    },
+  }));
 
   return (
     <Box>
@@ -180,25 +56,30 @@ export const DataTableList = ({
           沒有找到符合條件的資料表格。
         </Typography>
       ) : (
-        <>{viewMode === "card" ? renderCards() : renderList()}</>
+        <GenericListView
+          items={genericItems}
+          viewMode={viewMode}
+          onClickItem={(id) => handleTableClick(id)}
+          renderActions={(id) => (
+            <GenericItemActions
+              itemId={id}
+              actions={[
+                { key: "update", label: "更新" },
+                { key: "export", label: "匯出" },
+                { key: "delete", label: "刪除" },
+              ]}
+              onAction={handleAction}
+              confirmActions={["delete"]}
+              confirmMessages={{
+                delete: {
+                  title: "刪除資料表",
+                  content: "確定要刪除此資料表嗎？此操作無法復原。",
+                },
+              }}
+            />
+          )}
+        />
       )}
-      {/* 單一表格操作選單 (保持不變) */}
-      <Menu
-        anchorEl={anchorEl}
-        open={Boolean(anchorEl)}
-        onClose={handleMenuClose}
-      >
-        <MenuItem onClick={() => handleAction("更新")}>更新</MenuItem>
-        <MenuItem onClick={() => handleAction("下載")}>下載</MenuItem>
-        <MenuItem onClick={() => openDeleteDialog()}>刪除</MenuItem>
-      </Menu>
-      <DeleteWarningDialog
-        title="刪除資料表格"
-        content="確定要刪除這個資料表格嗎？此操作無法復原。"
-        open={openDialog}
-        handleClose={closeDeleteDialog}
-        handleComfirm={handleConfirmDelete}
-      />
     </Box>
   );
 };

--- a/src/components/common/GenericItemActions.tsx
+++ b/src/components/common/GenericItemActions.tsx
@@ -1,0 +1,121 @@
+// src/components/common/GenericItemActions.tsx
+import {
+  IconButton,
+  Menu,
+  MenuItem,
+  Dialog,
+  DialogTitle,
+  DialogContent,
+  DialogContentText,
+  DialogActions,
+  Button,
+} from "@mui/material";
+import MoreVertIcon from "@mui/icons-material/MoreVert";
+import { useState } from "react";
+import type { TableId } from "shared/types/dataTable";
+export type ActionType = "update" | "export" | "delete" | string;
+
+export interface GenericItemAction {
+  key: ActionType;
+  label: string;
+}
+
+export interface GenericItemActionsProps {
+  itemId: TableId;
+  actions: GenericItemAction[]; // e.g. [{ key: "update", label: "更新" }]
+  onAction: (action: ActionType, itemId: TableId) => void;
+
+  /** 哪些行為需要確認對話框 */
+  confirmActions?: ActionType[];
+
+  /** 對話框標題與內容，可根據動作自訂 */
+  confirmMessages?: Partial<
+    Record<ActionType, { title: string; content: string }>
+  >;
+
+  /** menu/dialog 開關狀態變更 callback */
+  onOpenChange?: (isOpen: boolean) => void;
+}
+
+export const GenericItemActions = ({
+  itemId,
+  actions,
+  onAction,
+  confirmActions = [],
+  confirmMessages = {},
+  onOpenChange,
+}: GenericItemActionsProps) => {
+  const [anchorEl, setAnchorEl] = useState<null | HTMLElement>(null);
+  const [pendingAction, setPendingAction] = useState<ActionType | null>(null);
+
+  const handleMenuClick = (event: React.MouseEvent<HTMLElement>) => {
+    setAnchorEl(event.currentTarget);
+    onOpenChange?.(true);
+  };
+
+  const handleMenuClose = () => {
+    setAnchorEl(null);
+    onOpenChange?.(false);
+  };
+
+  const handleActionClick = (action: ActionType) => {
+    if (confirmActions.includes(action)) {
+      setPendingAction(action);
+    } else {
+      onAction(action, itemId);
+      handleMenuClose();
+    }
+  };
+
+  const handleConfirm = () => {
+    if (pendingAction) onAction(pendingAction, itemId);
+    setPendingAction(null);
+    handleMenuClose();
+  };
+
+  const handleCancel = () => {
+    setPendingAction(null);
+  };
+
+  const currentConfirm = pendingAction
+    ? (confirmMessages[pendingAction] ?? {
+        title: "確認操作",
+        content: "確定要執行這個操作嗎？此動作無法復原。",
+      })
+    : null;
+
+  return (
+    <>
+      <IconButton onClick={handleMenuClick}>
+        <MoreVertIcon />
+      </IconButton>
+
+      <Menu
+        anchorEl={anchorEl}
+        open={Boolean(anchorEl)}
+        onClose={handleMenuClose}
+      >
+        {actions.map(({ key, label }) => (
+          <MenuItem key={key} onClick={() => handleActionClick(key)}>
+            {label}
+          </MenuItem>
+        ))}
+      </Menu>
+
+      {currentConfirm && (
+        <Dialog open onClose={handleCancel}>
+          <DialogTitle>{currentConfirm.title}</DialogTitle>
+          <DialogContent>
+            <DialogContentText>{currentConfirm.content}</DialogContentText>
+          </DialogContent>
+          <DialogActions>
+            <Button onClick={handleCancel}>取消</Button>
+            <Button onClick={handleConfirm} color="error">
+              確定
+            </Button>
+          </DialogActions>
+        </Dialog>
+      )}
+    </>
+  );
+};

--- a/src/components/common/GenericListView.tsx
+++ b/src/components/common/GenericListView.tsx
@@ -1,0 +1,106 @@
+// src/components/common/GenericListView.tsx
+import {
+  Box,
+  Card,
+  CardContent,
+  Typography,
+  Grid,
+  Table,
+  TableBody,
+  TableCell,
+  TableContainer,
+  TableHead,
+  TableRow,
+  Paper,
+  Link,
+} from "@mui/material";
+import type { DataRecord, TableId } from "shared/types/dataTable";
+
+export interface GenericItem {
+  id: TableId;
+  title: string;
+  updated_at?: string;
+  metadata?: DataRecord;
+}
+
+export interface GenericListViewProps {
+  items: GenericItem[];
+  viewMode: "card" | "list";
+  onClickItem: (id: TableId) => void;
+  renderActions?: (id: TableId) => React.ReactNode;
+}
+
+export const GenericListView = ({
+  items,
+  viewMode,
+  onClickItem,
+  renderActions,
+}: GenericListViewProps) => {
+  const renderList = () => (
+    <TableContainer component={Paper}>
+      <Table>
+        <TableHead>
+          <TableRow>
+            <TableCell>名稱</TableCell>
+            <TableCell>上傳日期</TableCell>
+            <TableCell>其他資訊</TableCell>
+            <TableCell align="right">操作</TableCell>
+          </TableRow>
+        </TableHead>
+        <TableBody>
+          {items.map((item) => (
+            <TableRow key={item.id}>
+              <TableCell>
+                <Link onClick={() => onClickItem(item.id)}>{item.title}</Link>
+              </TableCell>
+              <TableCell>{item.updated_at}</TableCell>
+              <TableCell>
+                {item.metadata &&
+                  Object.entries(item.metadata)
+                    .map(([k, v]) => `${k}: ${v}`)
+                    .join(" / ")}
+              </TableCell>
+              <TableCell align="right">{renderActions?.(item.id)}</TableCell>
+            </TableRow>
+          ))}
+        </TableBody>
+      </Table>
+    </TableContainer>
+  );
+
+  const renderCards = () => (
+    <Grid container spacing={3}>
+      {items.map((item) => (
+        <Grid size={{ xs: 12, sm: 6, md: 4 }} key={item.id}>
+          <Card variant="outlined">
+            <CardContent>
+              <Box
+                sx={{
+                  display: "flex",
+                  justifyContent: "space-between",
+                  alignItems: "center",
+                }}
+              >
+                <Typography variant="h6">
+                  <Link onClick={() => onClickItem(item.id)}>{item.title}</Link>
+                </Typography>
+                {renderActions?.(item.id)}
+              </Box>
+              <Typography variant="body2" color="text.secondary">
+                上傳日期: {item.updated_at}
+              </Typography>
+              {item.metadata &&
+                Object.entries(item.metadata).map(([k, v]) => (
+                  <Typography key={k} variant="body2" color="text.secondary">
+                    {k}: {v}
+                  </Typography>
+                ))}
+            </CardContent>
+          </Card>
+        </Grid>
+      ))}
+    </Grid>
+  );
+
+  return <Box>{viewMode === "card" ? renderCards() : renderList()}</Box>;
+};


### PR DESCRIPTION
## 📘 Summary / 摘要

This PR refactors the `DataTableList` component into a more generic, reusable structure by introducing `GenericListView` and `GenericItemActions` components.
本 PR 將原本專屬資料表的列表重構為可重用結構，透過新增 `GenericListView` 與 `GenericItemActions`，讓列表與操作行為模組化、抽象化。

---

## 🏗️ Major Changes / 主要變更

### ✳️ Components Added

* **`GenericListView`**

  * 通用列表／卡片視圖元件。
  * 支援 `viewMode="list" | "card"` 自動切換。
  * 提供 `renderActions` 介面注入操作按鈕。
  * 支援任意 metadata 顯示。

* **`GenericItemActions`**

  * 通用操作按鈕與選單元件。
  * 內建確認對話框（可設定需要確認的動作與自訂訊息）。
  * 適用於任何 item-based 資料操作（如刪除、匯出、更新）。

---

### 🧹 Refactored

* **`DataTableList.tsx`**

  * 移除冗長的 `Menu`, `Dialog`, `Grid`, `Table` 結構。
  * 改以 `GenericListView` + `GenericItemActions` 組合方式實現。
  * 實作統一的 `handleAction`，支援 `delete` 操作後自動刷新資料。
  * `useState` 狀態簡化（anchorEl、openDialog、selectedTableId 全移除）。
  * 轉換資料結構為 `GenericItem[]`，明確區分展示與資料層。

---

## ✅ Testing / 測試重點

* [ ] 在 **List / Card 模式** 下切換顯示正常
* [ ] 點擊名稱可導向表格編輯頁
* [ ] 操作選單 (更新 / 匯出 / 刪除) 正常顯示
* [ ] 刪除前顯示確認對話框
* [ ] 刪除後清單成功刷新
* [ ] 無資料時仍顯示提示文字

---

## 💡 Motivation / 動機

The original `DataTableList` was large and tightly coupled to MUI layout details.
By extracting `GenericListView` and `GenericItemActions`, we make it easy to reuse the same list structure for other entities (e.g., charts, datasets, logs).

原先的 `DataTableList` 結構龐雜且高度耦合於 MUI UI 細節。
透過抽象化後，未來可輕鬆重用於圖表、資料集、或其他物件清單展示。

---

## 🧠 Potential Follow-ups / 後續可考慮項目

* 加入「搜尋 / 排序」功能至 `GenericListView`
* 讓 `GenericItemActions` 支援 icon-only 模式或 tooltip 說明
* 將 `GenericListView` 整合進通用 CRUD 架構中