### PR TITLE
fix(upload): show remove button only after upload completes or fails

### DIFF
--- a/src/components/DataTablesPage/UploadStatusBar.tsx
+++ b/src/components/DataTablesPage/UploadStatusBar.tsx
@@ -121,9 +121,9 @@ export const UploadStatusBar: React.FC<UploadStatusBarProps> = ({
               </Typography>
             }
           />
-          {upload.status !== "success" && upload.status !== "failed" ? (
+          {(upload.status === "success" || upload.status === "failed") && (
             <RemoveUploadButton uploadId={upload.id} />
-          ) : null}
+          )}
         </>
       }
       detail={


### PR DESCRIPTION
Fixed incorrect condition that displayed the remove button during active uploads. Now it appears only when upload status is `success` or `failed`.

---
fix(upload): 修正上傳狀態列刪除按鈕顯示條件

修正邏輯錯誤，刪除按鈕現在僅在上傳成功或失敗後顯示，不再於上傳中顯示。