### PR TITLE
feat(dashboard, components, types): add dashboard management page and unify file-related types

### DIFF
--- a/electron/ipc/DataTableAPIHandlers.cts
+++ b/electron/ipc/DataTableAPIHandlers.cts
@@ -5,9 +5,8 @@ import {
   DataTableHeaderSchema,
   DataTableWithInfo,
   TableId,
-  UploadInputDataTableInfo,
 } from "shared/types/dataTable";
-import { UploadMode } from "shared/types/index";
+import { UploadInputInfo, UploadMode } from "shared/types/index";
 
 export const DataTableAPIHandlers: Record<string, IpcMainListener> = {
   // 上傳資料表
@@ -18,7 +17,7 @@ export const DataTableAPIHandlers: Record<string, IpcMainListener> = {
       content,
       uploadMode = "create",
     }: {
-      tableInfo: UploadInputDataTableInfo;
+      tableInfo: UploadInputInfo;
       content: DataTableHeaderSchema;
       uploadMode: UploadMode;
     }

--- a/electron/preload.cts
+++ b/electron/preload.cts
@@ -1,18 +1,22 @@
 console.log("Preload script loaded");
 import { contextBridge, ipcRenderer } from "electron";
-import type { ConflictResult, Message, UploadMode } from "shared/types";
+import type {
+  ConflictResult,
+  Message,
+  UploadMode,
+  UploadInputInfo,
+} from "shared/types";
 import type {
   DataTableHeaderSchema,
   DataTableInfo,
   DataTableWithInfo,
   TableId,
-  UploadInputDataTableInfo,
 } from "shared/types/dataTable";
 import type { ChartInfo } from "shared/types/chart";
 
 contextBridge.exposeInMainWorld("api", {
   uploadTable: (
-    tableInfo: UploadInputDataTableInfo,
+    tableInfo: UploadInputInfo,
     content: DataTableHeaderSchema,
     uploadMode: UploadMode = "create"
   ): Promise<DataTableInfo> =>

--- a/shared/types/dashboard.ts
+++ b/shared/types/dashboard.ts
@@ -1,0 +1,8 @@
+import type { FileInfo } from ".";
+
+export type SupportedFileType = "json";
+export type FileType = SupportedFileType | "unknown";
+export type DashboardInfo = FileInfo & {
+  chartCount: number;
+};
+export type DashboardId = DashboardInfo["id"];

--- a/shared/types/dataTable.ts
+++ b/shared/types/dataTable.ts
@@ -1,3 +1,5 @@
+import type { FileInfo } from ".";
+
 export type SupportedFileType = "csv" | "json";
 export type FileType = SupportedFileType | "unknown";
 export type ColumnType = "string" | "number" | "boolean" | "date";
@@ -6,21 +8,10 @@ export interface ColumnInfo {
   desc?: string;
   type: ColumnType;
 }
-export type TableId = string | number;
-export interface DataTableInfo {
-  id: TableId;
-  name: string;
-  description?: string;
-  file_path: string;
-  created_at: string;
-  updated_at: string;
-  fileSize?: string | number;
+export type DataTableInfo = FileInfo & {
   columnInfos?: ColumnInfo[];
-}
-export type UploadInputDataTableInfo = Pick<
-  DataTableInfo,
-  "name" | "description"
->;
+};
+export type TableId = DataTableInfo["id"];
 
 export type DataValue = string | number | boolean | null | undefined;
 export type DataRecord = Record<string, DataValue>;

--- a/shared/types/index.ts
+++ b/shared/types/index.ts
@@ -7,6 +7,17 @@ export interface ConflictResult {
 }
 
 export type UploadMode = "create" | "replace";
+export type FileId = string | number;
+export interface FileInfo {
+  id: FileId;
+  name: string;
+  description?: string;
+  file_path: string;
+  created_at: string;
+  updated_at: string;
+  fileSize?: string | number;
+}
+export type UploadInputInfo = Pick<FileInfo, "name" | "description">;
 
 export type Result<T, E> = Ok<T, E> | Err<T, E>;
 export class Ok<T, _> {

--- a/src/components/DashboardsPage/DashboardList.tsx
+++ b/src/components/DashboardsPage/DashboardList.tsx
@@ -1,0 +1,71 @@
+// src/components/DashboardsPage/DashboardList.tsx
+import { useNavigate } from "react-router-dom";
+import { Box } from "@mui/material";
+import { GenericListView, type GenericItem } from "../common/GenericListView";
+import { GenericItemActions } from "../common/GenericItemActions";
+import type { DashboardInfo } from "shared/types/dashboard";
+
+interface Props {
+  dashboards: DashboardInfo[];
+  viewMode: "card" | "list";
+  refresh: () => void;
+}
+
+export const DashboardList = ({ dashboards, viewMode, refresh }: Props) => {
+  const navigate = useNavigate();
+
+  // 點擊項目名稱時導向展示頁
+  const handleClickItem = (id: DashboardInfo["id"]) => {
+    navigate(`/dashboards/view/${id}`);
+  };
+
+  // 執行操作（更新、刪除等）
+  const handleAction = (action: string, id: DashboardInfo["id"]) => {
+    console.log(`對儀表板 ${id} 執行操作: ${action}`);
+    if (action === "刪除") {
+      //   window.api.deleteDashboard(id);
+      refresh();
+    }
+    // 其他操作邏輯可擴充
+  };
+
+  // 將 DashboardInfo 轉換成 GenericItem
+  const genericItems: GenericItem<DashboardInfo["id"]>[] = dashboards.map(
+    (d) => ({
+      id: d.id,
+      title: d.name,
+      subtitle: `更新時間：${d.updated_at}`,
+      metadata: {
+        圖表數量: d.chartCount.toString(),
+      },
+    })
+  );
+
+  return (
+    <Box>
+      <GenericListView
+        items={genericItems}
+        viewMode={viewMode}
+        onClickItem={handleClickItem}
+        renderActions={(id) => (
+          <GenericItemActions
+            itemId={id}
+            actions={[
+              { key: "update", label: "更新" },
+              { key: "export", label: "匯出" },
+              { key: "delete", label: "刪除" },
+            ]}
+            onAction={handleAction}
+            confirmActions={["delete"]}
+            confirmMessages={{
+              delete: {
+                title: "刪除儀表板",
+                content: "確定要刪除這個儀表板嗎？此操作無法復原。",
+              },
+            }}
+          />
+        )}
+      />
+    </Box>
+  );
+};

--- a/src/components/DataTablesPage/DataTableList.tsx
+++ b/src/components/DataTablesPage/DataTableList.tsx
@@ -36,7 +36,7 @@ export const DataTableList = ({ dataTables, viewMode, refresh }: Props) => {
   };
 
   // 將 DataTableInfo 轉換成 GenericItem
-  const genericItems: GenericItem[] = dataTables.map((table) => ({
+  const genericItems: GenericItem<TableId>[] = dataTables.map((table) => ({
     id: table.id,
     title: table.name,
     updated_at: table.updated_at,

--- a/src/components/common/GenericItemActions.tsx
+++ b/src/components/common/GenericItemActions.tsx
@@ -12,7 +12,6 @@ import {
 } from "@mui/material";
 import MoreVertIcon from "@mui/icons-material/MoreVert";
 import { useState } from "react";
-import type { TableId } from "shared/types/dataTable";
 export type ActionType = "update" | "export" | "delete" | string;
 
 export interface GenericItemAction {
@@ -20,10 +19,10 @@ export interface GenericItemAction {
   label: string;
 }
 
-export interface GenericItemActionsProps {
-  itemId: TableId;
+export interface GenericItemActionsProps<T> {
+  itemId: T;
   actions: GenericItemAction[]; // e.g. [{ key: "update", label: "更新" }]
-  onAction: (action: ActionType, itemId: TableId) => void;
+  onAction: (action: ActionType, itemId: T) => void;
 
   /** 哪些行為需要確認對話框 */
   confirmActions?: ActionType[];
@@ -37,14 +36,14 @@ export interface GenericItemActionsProps {
   onOpenChange?: (isOpen: boolean) => void;
 }
 
-export const GenericItemActions = ({
+export const GenericItemActions = <itemIdType,>({
   itemId,
   actions,
   onAction,
   confirmActions = [],
   confirmMessages = {},
   onOpenChange,
-}: GenericItemActionsProps) => {
+}: GenericItemActionsProps<itemIdType>) => {
   const [anchorEl, setAnchorEl] = useState<null | HTMLElement>(null);
   const [pendingAction, setPendingAction] = useState<ActionType | null>(null);
 

--- a/src/components/common/GenericListView.tsx
+++ b/src/components/common/GenericListView.tsx
@@ -14,28 +14,28 @@ import {
   Paper,
   Link,
 } from "@mui/material";
-import type { DataRecord, TableId } from "shared/types/dataTable";
+import type { DataRecord } from "shared/types/dataTable";
 
-export interface GenericItem {
-  id: TableId;
+export interface GenericItem<T> {
+  id: T;
   title: string;
   updated_at?: string;
   metadata?: DataRecord;
 }
 
-export interface GenericListViewProps {
-  items: GenericItem[];
+export interface GenericListViewProps<T> {
+  items: GenericItem<T>[];
   viewMode: "card" | "list";
-  onClickItem: (id: TableId) => void;
-  renderActions?: (id: TableId) => React.ReactNode;
+  onClickItem: (id: T) => void;
+  renderActions?: (id: T) => React.ReactNode;
 }
 
-export const GenericListView = ({
+export const GenericListView = <itemIdType extends React.Key>({
   items,
   viewMode,
   onClickItem,
   renderActions,
-}: GenericListViewProps) => {
+}: GenericListViewProps<itemIdType>) => {
   const renderList = () => (
     <TableContainer component={Paper}>
       <Table>

--- a/src/pages/DashboardsPage.tsx
+++ b/src/pages/DashboardsPage.tsx
@@ -1,12 +1,54 @@
 // src/pages/DashboardsPage.tsx
+import type { PageConfig } from "src/types";
 import { PageWrapper } from "../components/layout/PageWrapper";
+import { GenericListPage } from "../components/common/GenericListPage";
+import { useState } from "react";
+// import { useNavigate } from "react-router-dom";
+import type { DashboardInfo } from "shared/types/dashboard";
+import { DashboardList } from "../components/DashboardsPage/DashboardList";
 
 export const DashboardsPage = () => {
-  return (
-    <PageWrapper
-      breadcrumbItems={[{ label: "儀表板列表", path: "/dashboards" }]}
-      content={<div>DashboardsPage</div>}
-      rightPanelContent={<div>DashboardsPage</div>}
-    />
+  const [searchText, setSearchText] = useState("");
+  const [dashboardInfos, _setDashboardInfos] = useState<DashboardInfo[]>([]);
+  // const navigate = useNavigate();
+
+  const refreshDashboardInfos = () => {
+    // window.api.getAllDashboardInfos().then(setDashboardInfos);
+  };
+
+  // 根據搜尋關鍵字過濾資料
+  const filteredDashboards = dashboardInfos.filter((t) =>
+    t.name.toLowerCase().includes(searchText.toLowerCase())
   );
+
+  // 頁面配置
+  const pageConfig: Omit<PageConfig, "tocItems"> = {
+    breadcrumbItems: [{ label: "儀表板管理", path: "/dashboards" }],
+    content: (
+      <>
+        <GenericListPage
+          title="儀表板管理"
+          items={filteredDashboards}
+          searchable
+          // creatable
+          // uploadable
+          searchPlaceholder="搜尋儀表板"
+          onSearch={setSearchText}
+          // onCreate={() => handleNewDashboardClick()}
+          // onUpload={() => setUploadDialogOpen(true)}
+          renderList={(items, viewMode) => (
+            <DashboardList
+              dashboards={items}
+              viewMode={viewMode}
+              refresh={refreshDashboardInfos}
+            />
+          )}
+        />
+      </>
+    ),
+    rightPanelContent: null,
+    rightPanelTitle: "上傳狀態",
+  };
+
+  return <PageWrapper {...pageConfig} />;
 };

--- a/src/preload.d.ts
+++ b/src/preload.d.ts
@@ -5,13 +5,17 @@ import type {
   DataTableHeaderSchema,
   DataTableInfo,
   DataTableWithInfo,
-  UploadInputDataTableInfo,
 } from "shared/types/dataTable";
-import type { Message, ConflictResult, UploadMode } from "shared/types";
+import type {
+  Message,
+  ConflictResult,
+  UploadMode,
+  UploadInputInfo,
+} from "shared/types";
 import type { ChartInfo } from "shared/types/chart";
 interface DataTableAPI {
   uploadTable: (
-    tableInfo: UploadInputDataTableInfo,
+    tableInfo: UploadInputInfo,
     content: DataTableHeaderSchema,
     uploadMode: UploadMode
   ) => Promise<DataTableInfo>;


### PR DESCRIPTION
# PR Title
`feat(dashboard, components, types): add dashboard management page and unify file-related types`

# PR Description

## ✨ Feature Summary
- **Feature Name**: Dashboard Management
- **Feature Description**: Added a new dashboard management page with list rendering, search, and filtering. Integrated with reusable layout components and prepared for future create/upload features.

## 🔗 Related Issue / PR
- Closes #49

## 🔧 Changes
- [x] Added `DashboardList` component using `GenericListView` and `GenericItemActions`
- [x] Implemented `DashboardsPage` with search and filtering logic
- [x] Created new type `DashboardInfo` extending `FileInfo`
- [x] Unified file-related types (`FileInfo`, `UploadInputInfo`) and refactored `DataTableInfo`
- [x] Updated preload and IPC handlers to use new types
- [x] Refactored `GenericListView` and `GenericItemActions` to support generics

## ✅ Test Items
- [ ] Verify dashboard list renders correctly in both card and list views
- [ ] Test dashboard item click navigates to detail page
- [ ] Confirm delete action triggers refresh
- [ ] Validate type changes do not break existing data table upload flow

## ⚠️ Potential Impact
- [ ] Changes to shared types may affect other modules using `DataTableInfo`
- [ ] IPC and preload refactoring may impact Electron communication

---

# PR 標題
`feat(dashboard, components, types): 新增儀表板管理頁面並統一檔案相關型別`

# PR 說明

## ✨ 功能新增
- **功能名稱**：儀表板管理
- **功能說明**：新增儀表板管理頁面，支援列表顯示、搜尋與過濾，整合通用版面元件，並預留建立與上傳功能。

## 🔗 關聯 Issue / PR
- Closes #49

## 🛠️ 變更內容
- [x] 新增 `DashboardList` 元件，使用 `GenericListView` 與 `GenericItemActions`
- [x] 實作 `DashboardsPage`，包含搜尋與過濾邏輯
- [x] 建立 `DashboardInfo` 型別，繼承自 `FileInfo`
- [x] 統一檔案相關型別（`FileInfo`, `UploadInputInfo`），並重構 `DataTableInfo`
- [x] 更新 preload 與 IPC 處理邏輯以使用新型別
- [x] 重構 `GenericListView` 與 `GenericItemActions`，支援泛型型別

## ✅ 測試項目
- [ ] 驗證儀表板列表在卡片與清單模式下正確顯示
- [ ] 測試點擊項目可導向詳細頁面
- [ ] 確認刪除操作會觸發資料刷新
- [ ] 驗證型別變更不影響現有資料表上傳流程

## ⚠️ 可能的影響範圍
- [ ] 共享型別變更可能影響使用 `DataTableInfo` 的其他模組
- [ ] IPC 與 preload 重構可能影響 Electron 通訊流程